### PR TITLE
fix: resolve hydration mismatch from localStorage + SSR with Jotai

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import type { Metadata } from "next";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import type { ReactNode } from "react";
 import type { WebApplication, WithContext } from "schema-dts";
+import { Providers } from "@/app/providers";
 import { StructuredData } from "@/components/seo/structured-data";
 import { BASE_URL, title } from "@/config";
 
@@ -56,9 +57,11 @@ export default function RootLayout({
     <html lang="en" className={geist.className}>
       <body className="flex min-h-screen flex-col">
         <NuqsAdapter>
-          {children}
-          <Analytics />
-          <StructuredData data={schema} />
+          <Providers>
+            {children}
+            <Analytics />
+            <StructuredData data={schema} />
+          </Providers>
         </NuqsAdapter>
       </body>
     </html>

--- a/src/atoms/setting-atom.ts
+++ b/src/atoms/setting-atom.ts
@@ -1,4 +1,4 @@
-import { atomWithStorage } from "jotai/utils";
+import { atomWithStorage, createJSONStorage } from "jotai/utils";
 import type { Settings } from "@/types";
 
 const initialValue: Settings = {
@@ -7,9 +7,19 @@ const initialValue: Settings = {
   birthDate: "",
 };
 
+const storage = createJSONStorage<Settings>(() => {
+  if (typeof window === "undefined") {
+    return {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    };
+  }
+  return localStorage;
+});
+
 export const settingsAtom = atomWithStorage<Settings>(
   "settings",
   initialValue,
-  undefined,
-  { getOnInit: true },
+  storage,
 );


### PR DESCRIPTION
## Summary
- Replace `atomWithStorage` with SSR-safe `createJSONStorage` that guards `localStorage` access with a `typeof window` check
- Remove `getOnInit: true` so the atom starts with `initialValue` on both server and client, then hydrates from localStorage asynchronously on mount
- Activate the unused Jotai `Providers` component in root layout to provide proper store context

Fixes #61