### PR TITLE
feat: add progressive reveal step-by-step flow to calculator

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import type { Metadata } from "next";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import type { ReactNode } from "react";
 import type { WebApplication, WithContext } from "schema-dts";
+import { Providers } from "@/app/providers";
 import { StructuredData } from "@/components/seo/structured-data";
 import { BASE_URL, title } from "@/config";
 
@@ -56,9 +57,11 @@ export default function RootLayout({
     <html lang="en" className={geist.className}>
       <body className="flex min-h-screen flex-col">
         <NuqsAdapter>
-          {children}
-          <Analytics />
-          <StructuredData data={schema} />
+          <Providers>
+            {children}
+            <Analytics />
+            <StructuredData data={schema} />
+          </Providers>
         </NuqsAdapter>
       </body>
     </html>

--- a/src/atoms/form-step-atom.ts
+++ b/src/atoms/form-step-atom.ts
@@ -1,0 +1,17 @@
+import { atom } from "jotai";
+import { isValidDateFormat } from "@/utils/date-utils";
+import { settingsAtom } from "./setting-atom";
+
+export type FormStep = 0 | 1 | 2 | 3;
+
+export const formStepAtom = atom<FormStep>((get) => {
+  const { birthDate, monthlyGrossIncome } = get(settingsAtom);
+
+  const hasValidBirthDate = isValidDateFormat(birthDate);
+  const hasValidIncome = monthlyGrossIncome > 0;
+
+  if (!hasValidBirthDate && !hasValidIncome) return 0;
+  if (hasValidBirthDate && !hasValidIncome) return 1;
+  if (hasValidBirthDate && hasValidIncome) return 2;
+  return 0;
+});

--- a/src/atoms/setting-atom.ts
+++ b/src/atoms/setting-atom.ts
@@ -1,4 +1,4 @@
-import { atomWithStorage } from "jotai/utils";
+import { atomWithStorage, createJSONStorage } from "jotai/utils";
 import type { Settings } from "@/types";
 
 const initialValue: Settings = {
@@ -7,9 +7,19 @@ const initialValue: Settings = {
   birthDate: "",
 };
 
+const storage = createJSONStorage<Settings>(() => {
+  if (typeof window === "undefined") {
+    return {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    };
+  }
+  return localStorage;
+});
+
 export const settingsAtom = atomWithStorage<Settings>(
   "settings",
   initialValue,
-  undefined,
-  { getOnInit: true },
+  storage,
 );

--- a/src/components/calculator/calculator-content.tsx
+++ b/src/components/calculator/calculator-content.tsx
@@ -2,6 +2,7 @@
 
 import { useAtomValue } from "jotai";
 import { Suspense } from "react";
+import { formStepAtom } from "@/atoms/form-step-atom";
 import {
   distributionResultsAtom,
   hasCpfContributionAtom,
@@ -9,6 +10,7 @@ import {
 import { CalculatedResult } from "@/components/calculator/calculated-result";
 import CeilingComparisonCard from "@/components/calculator/ceiling-comparison-card";
 import DistributionView from "@/components/calculator/distribution-view";
+import StepSection from "@/components/calculator/step-section";
 import UserInput from "@/components/calculator/user-input";
 
 const ComparisonFallback = () => (
@@ -23,8 +25,10 @@ const DistributionFallback = () => (
 );
 
 const CalculatorContent = () => {
+  const step = useAtomValue(formStepAtom);
   const hasCpfContribution = useAtomValue(hasCpfContributionAtom);
   const distributionResults = useAtomValue(distributionResultsAtom);
+  const showResults = step >= 2;
 
   return (
     <div>
@@ -36,20 +40,24 @@ const CalculatorContent = () => {
         >
           <UserInput />
         </Suspense>
-        <Suspense
-          fallback={
-            <div className="h-96 animate-pulse rounded-lg bg-zinc-200" />
-          }
-        >
-          <CalculatedResult />
-        </Suspense>
+        <StepSection show={showResults}>
+          <Suspense
+            fallback={
+              <div className="h-96 animate-pulse rounded-lg bg-zinc-200" />
+            }
+          >
+            <CalculatedResult />
+          </Suspense>
+        </StepSection>
       </div>
-      <div className="mb-8">
-        <Suspense fallback={<ComparisonFallback />}>
-          <CeilingComparisonCard />
-        </Suspense>
-      </div>
-      {hasCpfContribution && (
+      <StepSection show={showResults} delay={0.1}>
+        <div className="mb-8">
+          <Suspense fallback={<ComparisonFallback />}>
+            <CeilingComparisonCard />
+          </Suspense>
+        </div>
+      </StepSection>
+      <StepSection show={showResults && hasCpfContribution} delay={0.2}>
         <Suspense fallback={<DistributionFallback />}>
           <div>
             <h2 className="mb-6 text-center font-semibold text-2xl">
@@ -58,7 +66,7 @@ const CalculatorContent = () => {
             <DistributionView distributionResults={distributionResults} />
           </div>
         </Suspense>
-      )}
+      </StepSection>
     </div>
   );
 };

--- a/src/components/calculator/step-section.tsx
+++ b/src/components/calculator/step-section.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { AnimatePresence, motion } from "motion/react";
+import type { ReactNode } from "react";
+
+interface StepSectionProps {
+  children: ReactNode;
+  show: boolean;
+  delay?: number;
+}
+
+const StepSection = ({ children, show, delay = 0 }: StepSectionProps) => {
+  return (
+    <AnimatePresence>
+      {show && (
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -16 }}
+          transition={{ duration: 0.4, delay, ease: "easeOut" }}
+        >
+          {children}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default StepSection;

--- a/src/components/calculator/user-input.tsx
+++ b/src/components/calculator/user-input.tsx
@@ -2,8 +2,8 @@ import { HelpCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useAtom, useAtomValue } from "jotai";
 import { useResetAtom } from "jotai/utils";
-import { formStepAtom } from "@/atoms/form-step-atom";
 import { type ChangeEvent, useCallback, useEffect, useTransition } from "react";
+import { formStepAtom } from "@/atoms/form-step-atom";
 import { settingsAtom } from "@/atoms/setting-atom";
 import { Button } from "@/components/ui/button";
 import {
@@ -170,7 +170,7 @@ const UserInput = () => {
         </div>
 
         {step === 1 && (
-          <div className="rounded-lg border border-dashed border-muted-foreground/30 bg-muted/50 p-4 text-center">
+          <div className="rounded-lg border border-muted-foreground/30 border-dashed bg-muted/50 p-4 text-center">
             <p className="text-muted-foreground text-sm">
               Enter your gross monthly income to see your CPF calculations
             </p>

--- a/src/components/calculator/user-input.tsx
+++ b/src/components/calculator/user-input.tsx
@@ -1,7 +1,8 @@
 import { HelpCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useAtom } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import { useResetAtom } from "jotai/utils";
+import { formStepAtom } from "@/atoms/form-step-atom";
 import { type ChangeEvent, useCallback, useEffect, useTransition } from "react";
 import { settingsAtom } from "@/atoms/setting-atom";
 import { Button } from "@/components/ui/button";
@@ -27,6 +28,7 @@ const UserInput = () => {
   const [settings, setSettings] = useAtom(settingsAtom);
   const { birthDate, monthlyGrossIncome, shouldStoreInput } = settings;
   const [isPending, startTransition] = useTransition();
+  const step = useAtomValue(formStepAtom);
 
   const resetSettings = useResetAtom(settingsAtom);
 
@@ -166,6 +168,14 @@ const UserInput = () => {
             browser. No data are being stored on any servers.
           </p>
         </div>
+
+        {step === 1 && (
+          <div className="rounded-lg border border-dashed border-muted-foreground/30 bg-muted/50 p-4 text-center">
+            <p className="text-muted-foreground text-sm">
+              Enter your gross monthly income to see your CPF calculations
+            </p>
+          </div>
+        )}
       </CardContent>
       <CardFooter className="flex justify-end">
         <Button variant="outline" onClick={handleReset} disabled={isPending}>

--- a/src/hooks/use-form-step.ts
+++ b/src/hooks/use-form-step.ts
@@ -1,0 +1,8 @@
+import { useAtomValue } from "jotai";
+import { formStepAtom } from "@/atoms/form-step-atom";
+
+const useFormStep = () => {
+  return useAtomValue(formStepAtom);
+};
+
+export default useFormStep;


### PR DESCRIPTION
## Summary
- Add `formStepAtom` derived from input validity (step 0: no input, step 1: birth date valid, step 2: both valid)
- Create `StepSection` animated wrapper using Motion `AnimatePresence` for progressive reveal with staggered delays
- Refactor `CalculatorContent` to gate result sections behind step progression — results, ceiling comparison, and distribution only appear when both inputs are valid
- Add income prompt hint when birth date is valid but income is missing (step 1)
- Includes hydration fix from #83 (SSR-safe `settingsAtom`)

Depends on #83 (should merge first)

Closes #55