### PR TITLE
Correct senior CPF rates and CPF LIFE payout figures

### DIFF
--- a/content/docs/api/ceiling/index.mdx
+++ b/content/docs/api/ceiling/index.mdx
@@ -70,7 +70,7 @@ curl https://simplycpf.com/api/cpf/ceiling/timeline
 
 ## Income Ceiling History
 
-Following the Ministry of Finance announcement at Singapore Budget 2023, the CPF income ceiling is being progressively raised:
+Following the Ministry of Finance announcement at Singapore Budget 2023, the CPF income ceiling was progressively raised, reaching its final value of $8,000 on 1 January 2026:
 
 | Effective Date | Ceiling |
 |----------------|---------|

--- a/src/app/api/cpf/calculate/route.test.ts
+++ b/src/app/api/cpf/calculate/route.test.ts
@@ -45,14 +45,24 @@ describe("POST /api/cpf/calculate", () => {
     expect(data.distribution).toHaveProperty("MA");
   });
 
-  it("should calculate CPF contribution for older age group", async () => {
-    const req = createRequest({ income: 5000, date: "2025-01-01", age: 58 });
+  // Senior rates and allocations per the CPF Board tables effective 1 Jan 2026.
+  it.each([
+    // age, employee, employer, total, OA, RA/SA, MA
+    [58, 900, 800, 1700, 600.1, 574.94, 524.96],
+    [62, 625, 625, 1250, 175, 550, 525],
+    [67, 375, 450, 825, 50.08, 249.97, 524.95],
+  ])("applies the 1 Jan 2026 senior rates at age %i", async (age, employee, employer, total, oa, sa, ma) => {
+    const req = createRequest({ income: 5000, date: "2026-01-01", age });
     const response = await POST(req);
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data.contribution.employee).toBe(750);
-    expect(data.contribution.employer).toBe(725);
+    expect(data.contribution.employee).toBe(employee);
+    expect(data.contribution.employer).toBe(employer);
+    expect(data.contribution.totalContribution).toBe(total);
+    expect(data.distribution.OA).toBe(oa);
+    expect(data.distribution.SA).toBe(sa);
+    expect(data.distribution.MA).toBe(ma);
   });
 
   it("should cap income at ceiling", async () => {

--- a/src/constants/cpf-data-as-of.ts
+++ b/src/constants/cpf-data-as-of.ts
@@ -1,0 +1,19 @@
+/**
+ * The effective date of the CPF figures shipped in `src/constants` and
+ * `src/data`. Surface this anywhere rates or sums are published so a reader,
+ * or a crawler, can tell how current the numbers are.
+ *
+ * Update this whenever a rate, ceiling, retirement sum or BHS value changes,
+ * in the same commit as the change.
+ *
+ * Latest change: contribution and allocation rates for the senior age bands,
+ * effective 1 January 2026.
+ * https://www.cpf.gov.sg/employer/employer-obligations/how-much-cpf-contributions-to-pay
+ */
+export const CPF_DATA_AS_OF = "2026-01-01";
+
+/** Human-readable form, for prose and footers. */
+export const CPF_DATA_AS_OF_LABEL = "1 January 2026";
+
+/** Calendar year the figures apply to. */
+export const CPF_DATA_AS_OF_YEAR = 2026;

--- a/src/constants/cpf-life.ts
+++ b/src/constants/cpf-life.ts
@@ -1,0 +1,19 @@
+/**
+ * Retirement Account balance at which a member born in 1958 or later is
+ * automatically included in CPF LIFE when their payouts begin.
+ *
+ * This is not the Basic Retirement Sum. The BRS is the amount set aside for a
+ * given payout level; this is the threshold for joining the scheme at all.
+ *
+ * https://www.cpf.gov.sg/member/retirement-income/monthly-payouts/cpf-life
+ */
+export const CPF_LIFE_AUTO_INCLUSION_BALANCE = 60_000;
+
+/** Earliest age monthly payouts can begin. */
+export const CPF_LIFE_PAYOUT_ELIGIBILITY_AGE = 65;
+
+/**
+ * Latest age payouts can be deferred to. With no instruction from the member,
+ * payouts start automatically at this age on the Standard Plan.
+ */
+export const CPF_LIFE_LATEST_PAYOUT_AGE = 70;

--- a/src/data/faq-calculator.json
+++ b/src/data/faq-calculator.json
@@ -13,6 +13,6 @@
   },
   {
     "question": "Does my age affect my CPF contribution rate?",
-    "answer": "Yes. CPF contribution rates decrease as you age. There are 8 age brackets: 55 and below (37% total), above 55 to 60 (26.5% total), above 60 to 65 (16.5% total), above 65 to 70 (12.5% total), and above 70 (10.5% total). The distribution across OA, SA, and MA also shifts — older workers see more allocated to SA and MA rather than OA."
+    "answer": "Yes. CPF contribution rates step down as you age. There are 8 age brackets: 55 and below (37% total), above 55 to 60 (34% total), above 60 to 65 (25% total), above 65 to 70 (16.5% total), and above 70 (12.5% total). The allocation across accounts also shifts: older workers see more allocated to MediSave rather than the Ordinary Account, and from 55 the middle share goes to the Retirement Account rather than the Special Account. Rates shown are those effective 1 January 2026."
   }
 ]

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -1,27 +1,27 @@
 [
   {
     "question": "How are CPF contributions calculated in Singapore?",
-    "answer": "CPF contributions are calculated based on your monthly gross income and age group. There are 8 age brackets, each with different employee and employer contribution rates. Your income is subject to CPF contributions up to the current income ceiling, which is rising progressively from $6,000 to $8,000 by September 2026 following Budget 2023. SimplyCPF handles all these variables automatically — just enter your income and birth date to get your exact contribution amounts."
+    "answer": "CPF contributions are calculated based on your monthly gross income and age group. There are 8 age brackets, each with different employee and employer contribution rates. Your income is subject to CPF contributions up to the current income ceiling, which rose in stages from $6,000 to $8,000 between September 2023 and January 2026 following Budget 2023. SimplyCPF handles all these variables automatically. Just enter your income and birth date to get your exact contribution amounts."
   },
   {
     "question": "What are the CPF contribution rates by age group?",
-    "answer": "CPF contribution rates vary by age group. For employees aged 55 and below, the total contribution rate is 37% (20% employee + 17% employer). Rates gradually decrease for older age groups: 56–60 years (26.5% total), 61–65 years (16.5% total), 66–70 years (12.5% total), and even lower for those above 70. The distribution across OA, SA, and MA also changes with age — older workers see more allocated to SA and MA rather than OA. Use the calculator to see the exact rates for your age group."
+    "answer": "CPF contribution rates vary by age group. For employees aged 55 and below, the total contribution rate is 37% (20% employee + 17% employer). Rates step down for older age groups: above 55 to 60 (34% total), above 60 to 65 (25% total), above 65 to 70 (16.5% total), and above 70 (12.5% total). The allocation across accounts also changes with age: older workers see more allocated to MediSave rather than the Ordinary Account, and from 55 the middle share goes to the Retirement Account because the Special Account no longer receives contributions. Rates shown are those effective 1 January 2026. Use the calculator to see the exact rates for your age group."
   },
   {
     "question": "How does the CPF income ceiling change affect my take-home pay?",
-    "answer": "The CPF income ceiling is rising from $6,000 to $8,000 in stages from September 2023 to September 2026. If your monthly income is above the old ceiling of $6,000, more of your income becomes subject to CPF contributions as the ceiling increases. This means your employee CPF contribution goes up and your take-home pay decreases slightly, but your total CPF savings (including employer contributions) increase. SimplyCPF's ceiling comparison feature shows you the exact dollar impact on both your take-home pay and your retirement savings."
+    "answer": "The CPF income ceiling rose from $6,000 to $8,000 in stages between September 2023 and January 2026. If your monthly income is above the old ceiling of $6,000, more of your income becomes subject to CPF contributions as the ceiling increases. This means your employee CPF contribution goes up and your take-home pay decreases slightly, but your total CPF savings (including employer contributions) increase. SimplyCPF's ceiling comparison feature shows you the exact dollar impact on both your take-home pay and your retirement savings."
   },
   {
     "question": "What is the difference between OA, SA, and MA in CPF?",
-    "answer": "CPF contributions are distributed across three accounts: the Ordinary Account (OA) for housing, insurance, investment, and education; the Special Account (SA) for retirement and retirement-related investments; and the MediSave Account (MA) for healthcare and medical insurance. The distribution varies by age — younger workers have more allocated to OA, while older workers see more going to SA and MA. The OA earns 2.5% p.a. (floor rate), while SA and MA earn a minimum of 4% p.a. with the potential to earn more when market rates are higher."
+    "answer": "CPF contributions are distributed across three accounts: the Ordinary Account (OA) for housing, insurance, investment, and education; the Special Account (SA) for retirement and retirement-related investments; and the MediSave Account (MA) for healthcare and medical insurance. The distribution varies by age: younger workers have more allocated to OA, while older workers see more going to SA and MA. The OA earns 2.5% p.a. (floor rate), while SA and MA earn a minimum of 4% p.a. with the potential to earn more when market rates are higher."
   },
   {
     "question": "Does SimplyCPF collect any of my data?",
-    "answer": "No data are being collected. The inputs are wiped on browser refresh. However, if you have checked the \"Store input on this browser\" checkbox, your input will be stored locally on your own browser only — no data are sent to or stored on any servers."
+    "answer": "No data are being collected. The inputs are wiped on browser refresh. However, if you have checked the \"Store input on this browser\" checkbox, your input will be stored locally on your own browser only, no data are sent to or stored on any servers."
   },
   {
     "question": "Do I need to sign up or log in to use SimplyCPF?",
-    "answer": "No sign-up or login is required. SimplyCPF is completely free and ungated — you can start calculating your CPF contributions immediately without creating an account or providing any personal information."
+    "answer": "No sign-up or login is required. SimplyCPF is completely free and ungated. You can start calculating your CPF contributions immediately without creating an account or providing any personal information."
   },
   {
     "question": "How are CPF interest rates determined?",
@@ -45,6 +45,6 @@
   },
   {
     "question": "I am a developer and I wish to contribute changes. How may I do so?",
-    "answer": "SimplyCPF is an open-source project released under the MIT licence. All contributions are welcome. Feel free to clone or fork the repository on GitHub and create a pull request. The project also provides a Developer API with 12 endpoints for programmatic access to CPF calculations — visit the developer documentation for details."
+    "answer": "SimplyCPF is an open-source project released under the MIT licence. All contributions are welcome. Feel free to clone or fork the repository on GitHub and create a pull request. The project also provides a Developer API with 12 endpoints for programmatic access to CPF calculations. Visit the developer documentation for details."
   }
 ]

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -4,6 +4,21 @@ import {
 } from "@/config";
 import type { AgeGroup } from "@/types";
 
+/**
+ * Contribution and allocation rates for Singapore Citizens and PRs from the
+ * 3rd year onwards, on monthly wages above $750. Effective 1 January 2026.
+ *
+ * Contribution rates: CPF Contribution Rate Table from 1 January 2026 (Table 1)
+ * https://www.cpf.gov.sg/content/dam/web/employer/employer-obligations/documents/CPFcontributionratesfrom1Jan2026.pdf
+ *
+ * Allocation rates: CPF Allocation Rates from 1 January 2026
+ * https://www.cpf.gov.sg/content/dam/web/employer/employer-obligations/documents/CPFAllocationRatesfromJanuary2026.pdf
+ *
+ * For ages 55 and above the `SA` key carries the Retirement Account share;
+ * the Special Account no longer receives contributions after its closure.
+ * Per CPF, those contributions go to the RA up to the Full Retirement Sum, and
+ * are channelled to the Ordinary Account once the FRS has been set aside.
+ */
 export const ageGroups: AgeGroup[] = [
   {
     description: "35 and below",
@@ -49,22 +64,22 @@ export const ageGroups: AgeGroup[] = [
     description: "Above 55 to 60",
     minAge: 55,
     maxAge: 60,
-    contributionRate: { employee: 0.15, employer: 0.145 },
-    distributionRate: { OA: 0.4069, SA: 0.2372, MA: 0.3559 },
+    contributionRate: { employee: 0.18, employer: 0.16 },
+    distributionRate: { OA: 0.353, SA: 0.3382, MA: 0.3088 },
   },
   {
     description: "Above 60 to 65",
     minAge: 60,
     maxAge: 65,
-    contributionRate: { employee: 0.095, employer: 0.11 },
-    distributionRate: { OA: 0.1709, SA: 0.317, MA: 0.5121 },
+    contributionRate: { employee: 0.125, employer: 0.125 },
+    distributionRate: { OA: 0.14, SA: 0.44, MA: 0.42 },
   },
   {
     description: "Above 65 to 70",
     minAge: 65,
     maxAge: 70,
-    contributionRate: { employee: 0.07, employer: 0.085 },
-    distributionRate: { OA: 0.0646, SA: 0.258, MA: 0.6774 },
+    contributionRate: { employee: 0.075, employer: 0.09 },
+    distributionRate: { OA: 0.0607, SA: 0.303, MA: 0.6363 },
   },
   {
     description: "Above 70",

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_EMPLOYER_CONTRIBUTION_RATE,
 } from "@/config";
 import type { AgeGroup } from "@/types";
+import { seniorDistributionRates } from "./senior-distribution-rates";
 
 /**
  * Contribution and allocation rates for Singapore Citizens and PRs from the
@@ -58,33 +59,33 @@ export const ageGroups: AgeGroup[] = [
       employee: DEFAULT_EMPLOYEE_CONTRIBUTION_RATE,
       employer: DEFAULT_EMPLOYER_CONTRIBUTION_RATE,
     },
-    distributionRate: { OA: 0.4055, SA: 0.3108, MA: 0.2837 },
+    distributionRate: seniorDistributionRates["Above 50 to 55"],
   },
   {
     description: "Above 55 to 60",
     minAge: 55,
     maxAge: 60,
     contributionRate: { employee: 0.18, employer: 0.16 },
-    distributionRate: { OA: 0.353, SA: 0.3382, MA: 0.3088 },
+    distributionRate: seniorDistributionRates["Above 55 to 60"],
   },
   {
     description: "Above 60 to 65",
     minAge: 60,
     maxAge: 65,
     contributionRate: { employee: 0.125, employer: 0.125 },
-    distributionRate: { OA: 0.14, SA: 0.44, MA: 0.42 },
+    distributionRate: seniorDistributionRates["Above 60 to 65"],
   },
   {
     description: "Above 65 to 70",
     minAge: 65,
     maxAge: 70,
     contributionRate: { employee: 0.075, employer: 0.09 },
-    distributionRate: { OA: 0.0607, SA: 0.303, MA: 0.6363 },
+    distributionRate: seniorDistributionRates["Above 65 to 70"],
   },
   {
     description: "Above 70",
     minAge: 70,
     contributionRate: { employee: 0.05, employer: 0.075 },
-    distributionRate: { OA: 0.08, SA: 0.08, MA: 0.84 },
+    distributionRate: seniorDistributionRates["Above 70"],
   },
 ];

--- a/src/data/permanent-resident-rates.ts
+++ b/src/data/permanent-resident-rates.ts
@@ -1,5 +1,22 @@
 import type { AgeGroup } from "@/types";
 
+/**
+ * Graduated (G/G) contribution rates for Permanent Residents in their 1st and
+ * 2nd year of SPR status, on monthly wages above $750. Allocation rates do not
+ * vary by residency status; they are the same age-based ratios used for
+ * citizens in src/data/index.ts.
+ *
+ * Contribution rates: CPF Contribution Rate Table from 1 January 2026,
+ * Tables 2 and 3. Unchanged since 1 January 2016.
+ * https://www.cpf.gov.sg/content/dam/web/employer/employer-obligations/documents/CPFcontributionratesfrom1Jan2026.pdf
+ *
+ * Allocation rates: CPF Allocation Rates from 1 January 2026.
+ * https://www.cpf.gov.sg/content/dam/web/employer/employer-obligations/documents/CPFAllocationRatesfromJanuary2026.pdf
+ *
+ * Not modelled: PRs whose employer has an approved joint application to
+ * contribute at full employer / full employee (F/F) rates, who use the
+ * citizen table instead.
+ */
 export const permanentResidentYear1Rates: AgeGroup[] = [
   {
     description: "35 and below",
@@ -34,21 +51,21 @@ export const permanentResidentYear1Rates: AgeGroup[] = [
     minAge: 55,
     maxAge: 60,
     contributionRate: { employee: 0.05, employer: 0.04 },
-    distributionRate: { OA: 0.4069, SA: 0.2372, MA: 0.3559 },
+    distributionRate: { OA: 0.353, SA: 0.3382, MA: 0.3088 },
   },
   {
     description: "Above 60 to 65",
     minAge: 60,
     maxAge: 65,
     contributionRate: { employee: 0.05, employer: 0.035 },
-    distributionRate: { OA: 0.1709, SA: 0.317, MA: 0.5121 },
+    distributionRate: { OA: 0.14, SA: 0.44, MA: 0.42 },
   },
   {
     description: "Above 65 to 70",
     minAge: 65,
     maxAge: 70,
     contributionRate: { employee: 0.05, employer: 0.035 },
-    distributionRate: { OA: 0.0646, SA: 0.258, MA: 0.6774 },
+    distributionRate: { OA: 0.0607, SA: 0.303, MA: 0.6363 },
   },
   {
     description: "Above 70",
@@ -92,21 +109,21 @@ export const permanentResidentYear2Rates: AgeGroup[] = [
     minAge: 55,
     maxAge: 60,
     contributionRate: { employee: 0.125, employer: 0.06 },
-    distributionRate: { OA: 0.4069, SA: 0.2372, MA: 0.3559 },
+    distributionRate: { OA: 0.353, SA: 0.3382, MA: 0.3088 },
   },
   {
     description: "Above 60 to 65",
     minAge: 60,
     maxAge: 65,
     contributionRate: { employee: 0.075, employer: 0.035 },
-    distributionRate: { OA: 0.1709, SA: 0.317, MA: 0.5121 },
+    distributionRate: { OA: 0.14, SA: 0.44, MA: 0.42 },
   },
   {
     description: "Above 65 to 70",
     minAge: 65,
     maxAge: 70,
     contributionRate: { employee: 0.05, employer: 0.035 },
-    distributionRate: { OA: 0.0646, SA: 0.258, MA: 0.6774 },
+    distributionRate: { OA: 0.0607, SA: 0.303, MA: 0.6363 },
   },
   {
     description: "Above 70",

--- a/src/data/permanent-resident-rates.ts
+++ b/src/data/permanent-resident-rates.ts
@@ -1,4 +1,5 @@
 import type { AgeGroup } from "@/types";
+import { seniorDistributionRates } from "./senior-distribution-rates";
 
 /**
  * Graduated (G/G) contribution rates for Permanent Residents in their 1st and
@@ -17,7 +18,8 @@ import type { AgeGroup } from "@/types";
  * contribute at full employer / full employee (F/F) rates, who use the
  * citizen table instead.
  */
-const baseYear1Rates: AgeGroup[] = [
+
+export const permanentResidentYear1Rates: AgeGroup[] = [
   {
     description: "35 and below",
     minAge: 0,
@@ -44,38 +46,36 @@ const baseYear1Rates: AgeGroup[] = [
     minAge: 50,
     maxAge: 55,
     contributionRate: { employee: 0.05, employer: 0.04 },
-    distributionRate: { OA: 0.4055, SA: 0.3108, MA: 0.2837 },
+    distributionRate: seniorDistributionRates["Above 50 to 55"],
   },
   {
     description: "Above 55 to 60",
     minAge: 55,
     maxAge: 60,
     contributionRate: { employee: 0.05, employer: 0.04 },
-    distributionRate: { OA: 0.353, SA: 0.3382, MA: 0.3088 },
+    distributionRate: seniorDistributionRates["Above 55 to 60"],
   },
   {
     description: "Above 60 to 65",
     minAge: 60,
     maxAge: 65,
     contributionRate: { employee: 0.05, employer: 0.035 },
-    distributionRate: { OA: 0.14, SA: 0.44, MA: 0.42 },
+    distributionRate: seniorDistributionRates["Above 60 to 65"],
   },
   {
     description: "Above 65 to 70",
     minAge: 65,
     maxAge: 70,
     contributionRate: { employee: 0.05, employer: 0.035 },
-    distributionRate: { OA: 0.0607, SA: 0.303, MA: 0.6363 },
+    distributionRate: seniorDistributionRates["Above 65 to 70"],
   },
   {
     description: "Above 70",
     minAge: 70,
     contributionRate: { employee: 0.05, employer: 0.035 },
-    distributionRate: { OA: 0.08, SA: 0.08, MA: 0.84 },
+    distributionRate: seniorDistributionRates["Above 70"],
   },
 ];
-
-export const permanentResidentYear1Rates = [...baseYear1Rates];
 
 export const permanentResidentYear2Rates: AgeGroup[] = [
   {
@@ -104,33 +104,33 @@ export const permanentResidentYear2Rates: AgeGroup[] = [
     minAge: 50,
     maxAge: 55,
     contributionRate: { employee: 0.15, employer: 0.09 },
-    distributionRate: { OA: 0.4055, SA: 0.3108, MA: 0.2837 },
+    distributionRate: seniorDistributionRates["Above 50 to 55"],
   },
   {
     description: "Above 55 to 60",
     minAge: 55,
     maxAge: 60,
     contributionRate: { employee: 0.125, employer: 0.06 },
-    distributionRate: { OA: 0.353, SA: 0.3382, MA: 0.3088 },
+    distributionRate: seniorDistributionRates["Above 55 to 60"],
   },
   {
     description: "Above 60 to 65",
     minAge: 60,
     maxAge: 65,
     contributionRate: { employee: 0.075, employer: 0.035 },
-    distributionRate: { OA: 0.14, SA: 0.44, MA: 0.42 },
+    distributionRate: seniorDistributionRates["Above 60 to 65"],
   },
   {
     description: "Above 65 to 70",
     minAge: 65,
     maxAge: 70,
     contributionRate: { employee: 0.05, employer: 0.035 },
-    distributionRate: { OA: 0.0607, SA: 0.303, MA: 0.6363 },
+    distributionRate: seniorDistributionRates["Above 65 to 70"],
   },
   {
     description: "Above 70",
     minAge: 70,
     contributionRate: { employee: 0.05, employer: 0.035 },
-    distributionRate: { OA: 0.08, SA: 0.08, MA: 0.84 },
+    distributionRate: seniorDistributionRates["Above 70"],
   },
 ];

--- a/src/data/permanent-resident-rates.ts
+++ b/src/data/permanent-resident-rates.ts
@@ -17,7 +17,7 @@ import type { AgeGroup } from "@/types";
  * contribute at full employer / full employee (F/F) rates, who use the
  * citizen table instead.
  */
-export const permanentResidentYear1Rates: AgeGroup[] = [
+const baseYear1Rates: AgeGroup[] = [
   {
     description: "35 and below",
     minAge: 0,
@@ -74,6 +74,8 @@ export const permanentResidentYear1Rates: AgeGroup[] = [
     distributionRate: { OA: 0.08, SA: 0.08, MA: 0.84 },
   },
 ];
+
+export const permanentResidentYear1Rates = [...baseYear1Rates];
 
 export const permanentResidentYear2Rates: AgeGroup[] = [
   {

--- a/src/data/senior-distribution-rates.ts
+++ b/src/data/senior-distribution-rates.ts
@@ -1,0 +1,14 @@
+import type { DistributionRate } from "@/types";
+
+/**
+ * Shared age group distribution rates that are duplicated across citizen and
+ * PR tables. These are the allocation rates for age groups where allocation
+ * does not vary by residency status.
+ */
+export const seniorDistributionRates: Record<string, DistributionRate> = {
+  "Above 50 to 55": { OA: 0.4055, SA: 0.3108, MA: 0.2837 },
+  "Above 55 to 60": { OA: 0.353, SA: 0.3382, MA: 0.3088 },
+  "Above 60 to 65": { OA: 0.14, SA: 0.44, MA: 0.42 },
+  "Above 65 to 70": { OA: 0.0607, SA: 0.303, MA: 0.6363 },
+  "Above 70": { OA: 0.08, SA: 0.08, MA: 0.84 },
+};

--- a/src/lib/calculate-cpf-projection.ts
+++ b/src/lib/calculate-cpf-projection.ts
@@ -26,7 +26,11 @@ import type {
   YearlyBalance,
 } from "@/types";
 
-const CPF_LIFE_PAYOUT_FACTOR = 0.008;
+// Anchored to the CPF Board's published example: the 2025 ERS of $426,000 set
+// aside at 55 corresponds to payouts of about $3,300/month from 65. The RA
+// grows at the 4% floor for the 10 years in between, so the factor applies to
+// the balance at payout start. https://www.cpf.gov.sg/member/infohub/news/media-news/why-it-pays-to-plan-for-retirement-income-of-up-to-3300-from-your-cpf
+const CPF_LIFE_PAYOUT_FACTOR = 3300 / (426_000 * 1.04 ** 10);
 const CPF_LIFE_ESCALATING_START_RATIO = 0.8;
 const CPF_LIFE_BASIC_RATIO = 0.9;
 const CPF_LIFE_DEFER_ANNUAL_INCREASE = 0.07;

--- a/src/lib/calculate-cpf-projection.ts
+++ b/src/lib/calculate-cpf-projection.ts
@@ -7,6 +7,7 @@ import {
   CPF_EXTRA_INTEREST_RATE,
   CPF_OA_EXTRA_INTEREST_CAP,
 } from "@/constants/cpf-interest-tiers";
+import { CPF_LIFE_AUTO_INCLUSION_BALANCE } from "@/constants/cpf-life";
 import { getRetirementSumsForYear } from "@/constants/cpf-retirement-sums";
 import { ageGroups } from "@/data";
 import {
@@ -30,7 +31,6 @@ const CPF_LIFE_ESCALATING_START_RATIO = 0.8;
 const CPF_LIFE_BASIC_RATIO = 0.9;
 const CPF_LIFE_DEFER_ANNUAL_INCREASE = 0.07;
 const CPF_LIFE_MAX_DEFER_YEARS = 5;
-const CPF_LIFE_MIN_RETIREMENT_SAVINGS = 60_000;
 const TAX_RELIEF_SELF = 8_000;
 
 function getAgeGroupsForCitizenship(citizenship: CitizenshipStatus) {
@@ -197,7 +197,7 @@ export function estimateCpfLife(
   raBalance: number,
   currentAge = 65,
 ): CpfLifeEstimate {
-  if (raBalance < CPF_LIFE_MIN_RETIREMENT_SAVINGS) {
+  if (raBalance < CPF_LIFE_AUTO_INCLUSION_BALANCE) {
     return {
       standardMonthly: 0,
       escalatingStartMonthly: 0,


### PR DESCRIPTION
- Correct the contribution and allocation rates for the three senior age bands against the CPF Board tables effective 1 January 2026 (above 55 to 60: 29.5% to 34%, above 60 to 65: 20.5% to 25%, above 65 to 70: 15.5% to 16.5%); every projection for a member over 55 was wrong
- Share one allocation table between citizens and PRs, since allocation varies by age only, and make every band sum to 1
- Fix the CPF LIFE joining threshold, which was documented as the Basic Retirement Sum when it is $60,000 in the Retirement Account at payout start, and pin the ERS multiple to the constants rather than a hardcoded 3x that predated the 2025 move to 4x
- Derive the CPF LIFE payout factor from CPF Board's published example (2025 ERS of $426,000 at 55 gives roughly $3,300 a month from 65) instead of a flat 0.008 that overstated payouts by about 50%

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
