### PR TITLE
Pin number and locale formatting to en-SG

### DIFF
--- a/src/app/cpf-rates.md/route.ts
+++ b/src/app/cpf-rates.md/route.ts
@@ -5,6 +5,7 @@ import {
 import {
   CPF_INCOME_CEILING,
   CPF_INCOME_CEILING_BEFORE_SEPT_2023,
+  getCeilingForYear,
 } from "@/constants";
 import { CPF_BASIC_HEALTHCARE_SUM } from "@/constants/cpf-bhs";
 import {
@@ -179,7 +180,7 @@ ${bhsRows}
 ## Key Statistics (${CPF_DATA_AS_OF_YEAR})
 
 - **Default total contribution rate (age ≤ 55):** ${fmtPct(DEFAULT_EMPLOYEE_CONTRIBUTION_RATE + DEFAULT_EMPLOYER_CONTRIBUTION_RATE)} (20% employee + 17% employer)
-- **Current income ceiling:** S$${formatNumber(CPF_INCOME_CEILING["2026-01-01"])} (from 1 January 2026, the final step of the Budget 2023 increase)
+- **Current income ceiling:** S$${formatNumber(getCeilingForYear(CPF_DATA_AS_OF_YEAR))} (from 1 January 2026, the final step of the Budget 2023 increase)
 - **OA floor interest rate:** ${CPF_INTEREST_FLOOR_RATES.OA}% p.a.
 - **SMRA floor interest rate:** ${CPF_INTEREST_FLOOR_RATES.SMRA}% p.a.
 - **Extra interest tier:** ${CPF_EXTRA_INTEREST_RATE * 100}% on first S$${formatNumber(CPF_EXTRA_INTEREST_CAP)} (OA capped at S$${formatNumber(CPF_OA_EXTRA_INTEREST_CAP)})

--- a/src/app/cpf-rates.md/route.ts
+++ b/src/app/cpf-rates.md/route.ts
@@ -8,6 +8,10 @@ import {
 } from "@/constants";
 import { CPF_BASIC_HEALTHCARE_SUM } from "@/constants/cpf-bhs";
 import {
+  CPF_DATA_AS_OF_LABEL,
+  CPF_DATA_AS_OF_YEAR,
+} from "@/constants/cpf-data-as-of";
+import {
   CPF_ACCOUNT_INTEREST_MAP,
   CPF_INTEREST_FLOOR_RATES,
   PEGGED_RATE_MARKUP,
@@ -24,6 +28,7 @@ import {
   permanentResidentYear1Rates,
   permanentResidentYear2Rates,
 } from "@/data/permanent-resident-rates";
+import { formatNumber } from "@/lib/format";
 
 export const revalidate = false;
 
@@ -44,7 +49,7 @@ const distributionRows = ageGroups
   .join("\n");
 
 const ceilingRows = Object.entries(CPF_INCOME_CEILING)
-  .map(([date, ceiling]) => `| ${date} | S$${ceiling.toLocaleString()} |`)
+  .map(([date, ceiling]) => `| ${date} | S$${formatNumber(ceiling)} |`)
   .join("\n");
 
 const quarterlyRows = QUARTERLY_CPF_RATES.map(
@@ -68,17 +73,17 @@ const prYear2Rows = permanentResidentYear2Rates
 const retirementSumRows = Object.entries(CPF_RETIREMENT_SUMS)
   .map(
     ([year, sums]) =>
-      `| ${year} | S$${sums.brs.toLocaleString()} | S$${sums.frs.toLocaleString()} | S$${sums.ers.toLocaleString()} |`,
+      `| ${year} | S$${formatNumber(sums.brs)} | S$${formatNumber(sums.frs)} | S$${formatNumber(sums.ers)} |`,
   )
   .join("\n");
 
 const bhsRows = Object.entries(CPF_BASIC_HEALTHCARE_SUM)
-  .map(([year, bhs]) => `| ${year} | S$${bhs.toLocaleString()} |`)
+  .map(([year, bhs]) => `| ${year} | S$${formatNumber(bhs)} |`)
   .join("\n");
 
-const cpfRatesMd = `# CPF Rates — Machine-Readable Reference
+const cpfRatesMd = `# CPF Rates: Machine-Readable Reference
 
-> Source: SimplyCPF (https://simplycpf.com) — All rates sourced from CPF Board publications.
+> Source: SimplyCPF (https://simplycpf.com): All rates sourced from CPF Board publications.
 
 ## Definition: CPF
 
@@ -86,7 +91,7 @@ CPF (Central Provident Fund) is Singapore's mandatory social security savings sc
 
 ## Definition: CPF Income Ceiling
 
-The CPF income ceiling is the maximum amount of monthly salary subject to CPF contributions. Any income above this ceiling is not subject to CPF. Following Budget 2023, the ceiling is rising progressively from S$6,000 to S$8,000 by 2026.
+The CPF income ceiling is the maximum amount of monthly salary subject to CPF contributions. Any income above this ceiling is not subject to CPF. Following Budget 2023, the ceiling rose in stages from S$6,000 to S$8,000, reaching S$8,000 on 1 January 2026.
 
 ---
 
@@ -106,7 +111,7 @@ ${distributionRows}
 
 | Effective Date | Monthly Ceiling |
 |---------------|----------------|
-| Pre-September 2023 | S$${CPF_INCOME_CEILING_BEFORE_SEPT_2023.toLocaleString()} |
+| Pre-September 2023 | S$${formatNumber(CPF_INCOME_CEILING_BEFORE_SEPT_2023)} |
 ${ceilingRows}
 
 ## Interest Rates
@@ -130,8 +135,8 @@ ${quarterlyRows}
 
 ### Extra Interest Tiers
 
-- Extra interest rate: ${CPF_EXTRA_INTEREST_RATE * 100}% on the first S$${CPF_EXTRA_INTEREST_CAP.toLocaleString()} combined
-- OA portion eligible for the extra interest is capped at the first S$${CPF_OA_EXTRA_INTEREST_CAP.toLocaleString()}
+- Extra interest rate: ${CPF_EXTRA_INTEREST_RATE * 100}% on the first S$${formatNumber(CPF_EXTRA_INTEREST_CAP)} combined
+- OA portion eligible for the extra interest is capped at the first S$${formatNumber(CPF_OA_EXTRA_INTEREST_CAP)}
 
 ## PR Graduated Rates
 
@@ -169,22 +174,23 @@ ${bhsRows}
 6. OA amount = total_contribution × OA_distribution_rate
 7. SA amount = total_contribution × SA_distribution_rate
 8. MA amount = total_contribution × MA_distribution_rate
-9. Take-home pay = monthly_income − employee_contribution
+9. Take-home pay = monthly_income - employee_contribution
 
-## Key Statistics (2025)
+## Key Statistics (${CPF_DATA_AS_OF_YEAR})
 
 - **Default total contribution rate (age ≤ 55):** ${fmtPct(DEFAULT_EMPLOYEE_CONTRIBUTION_RATE + DEFAULT_EMPLOYER_CONTRIBUTION_RATE)} (20% employee + 17% employer)
-- **Current income ceiling (2025):** S$${CPF_INCOME_CEILING["2025-01-01"].toLocaleString()}
-- **Final income ceiling (2026):** S$${CPF_INCOME_CEILING["2026-01-01"].toLocaleString()}
+- **Current income ceiling:** S$${formatNumber(CPF_INCOME_CEILING["2026-01-01"])} (from 1 January 2026, the final step of the Budget 2023 increase)
 - **OA floor interest rate:** ${CPF_INTEREST_FLOOR_RATES.OA}% p.a.
 - **SMRA floor interest rate:** ${CPF_INTEREST_FLOOR_RATES.SMRA}% p.a.
-- **Extra interest tier:** ${CPF_EXTRA_INTEREST_RATE * 100}% on first S$${CPF_EXTRA_INTEREST_CAP.toLocaleString()} (OA capped at S$${CPF_OA_EXTRA_INTEREST_CAP.toLocaleString()})
-- **Age brackets:** 8 (0–35, 36–45, 46–50, 51–55, 56–60, 61–65, 66–70, 70+)
-- **Ceiling increase (2023–2026):** 33.3% (S$6,000 → S$8,000)
+- **Extra interest tier:** ${CPF_EXTRA_INTEREST_RATE * 100}% on first S$${formatNumber(CPF_EXTRA_INTEREST_CAP)} (OA capped at S$${formatNumber(CPF_OA_EXTRA_INTEREST_CAP)})
+- **Age brackets:** 8 (0-35, 36-45, 46-50, 51-55, 56-60, 61-65, 66-70, 70+)
+- **Ceiling increase (2023-2026):** 33.3% (S$6,000 → S$8,000)
 
 ---
 
-*Data sourced from CPF Board publications. Last updated: 2025. This document is intended for machine consumption by AI agents and search engines. Visit https://simplycpf.com for the interactive calculator.*
+*Data sourced from CPF Board publications, effective ${CPF_DATA_AS_OF_LABEL}. This document is intended for machine consumption by AI agents and search engines. Visit https://simplycpf.com for the interactive calculator.*
+
+*SimplyCPF is independent and not affiliated with the CPF Board. Figures are estimates based on published rates and are not financial advice.*
 `;
 
 export async function GET(): Promise<Response> {

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -10,6 +10,7 @@ import {
   CPF_INCOME_CEILING_BEFORE_SEPT_2023,
 } from "@/constants";
 import { CPF_BASIC_HEALTHCARE_SUM } from "@/constants/cpf-bhs";
+import { CPF_DATA_AS_OF_LABEL } from "@/constants/cpf-data-as-of";
 import {
   CPF_INTEREST_FLOOR_RATES,
   PEGGED_RATE_MARKUP,
@@ -25,6 +26,7 @@ import {
   permanentResidentYear1Rates,
   permanentResidentYear2Rates,
 } from "@/data/permanent-resident-rates";
+import { formatNumber } from "@/lib/format";
 
 export const revalidate = false;
 
@@ -49,7 +51,7 @@ const distributionRatesSection = ageGroups
   .join("\n");
 
 const ceilingEntries = Object.entries(CPF_INCOME_CEILING)
-  .map(([date, ceiling]) => `| ${date} | S$${ceiling.toLocaleString()} |`)
+  .map(([date, ceiling]) => `| ${date} | S$${formatNumber(ceiling)} |`)
   .join("\n");
 
 const prYear1Section = permanentResidentYear1Rates
@@ -69,12 +71,12 @@ const prYear2Section = permanentResidentYear2Rates
 const retirementSumsSection = Object.entries(CPF_RETIREMENT_SUMS)
   .map(
     ([year, sums]) =>
-      `| ${year} | S$${sums.brs.toLocaleString()} | S$${sums.frs.toLocaleString()} | S$${sums.ers.toLocaleString()} |`,
+      `| ${year} | S$${formatNumber(sums.brs)} | S$${formatNumber(sums.frs)} | S$${formatNumber(sums.ers)} |`,
   )
   .join("\n");
 
 const bhsSection = Object.entries(CPF_BASIC_HEALTHCARE_SUM)
-  .map(([year, bhs]) => `| ${year} | S$${bhs.toLocaleString()} |`)
+  .map(([year, bhs]) => `| ${year} | S$${formatNumber(bhs)} |`)
   .join("\n");
 
 const llmsTxt = `# ${title}
@@ -109,11 +111,11 @@ ${distributionRatesSection}
 
 ## CPF Income Ceiling Timeline (Budget 2023)
 
-The CPF income ceiling is increasing progressively from S$6,000 to S$8,000 by 2026.
+The CPF income ceiling rose in stages from S$6,000 to S$8,000, reaching S$8,000 on 1 January 2026.
 
 | Effective Date | Monthly Income Ceiling |
 |---------------|----------------------|
-| Pre-September 2023 | S$${CPF_INCOME_CEILING_BEFORE_SEPT_2023.toLocaleString()} |
+| Pre-September 2023 | S$${formatNumber(CPF_INCOME_CEILING_BEFORE_SEPT_2023)} |
 ${ceilingEntries}
 
 - Income above the ceiling is NOT subject to CPF contributions
@@ -133,8 +135,8 @@ ${ceilingEntries}
 
 ## CPF Extra Interest Tiers
 
-- Extra interest rate: ${CPF_EXTRA_INTEREST_RATE * 100}% on the first S$${CPF_EXTRA_INTEREST_CAP.toLocaleString()} combined
-- OA portion eligible for the extra interest is capped at the first S$${CPF_OA_EXTRA_INTEREST_CAP.toLocaleString()}
+- Extra interest rate: ${CPF_EXTRA_INTEREST_RATE * 100}% on the first S$${formatNumber(CPF_EXTRA_INTEREST_CAP)} combined
+- OA portion eligible for the extra interest is capped at the first S$${formatNumber(CPF_OA_EXTRA_INTEREST_CAP)}
 - After age 55, the extra interest on the OA portion is redirected to the Retirement Account
 
 ## CPF Retirement Sums
@@ -167,7 +169,7 @@ ${prYear2Section}
 
 For an employee with monthly income I, age group G, and ceiling C:
 
-1. Capped Income = min(I, C) — income above the ceiling is excluded
+1. Capped Income = min(I, C), income above the ceiling is excluded
 2. Employee Contribution = Employee Rate × Capped Income
 3. Employer Contribution = Employer Rate × Capped Income
 4. Total CPF Contribution = Employee + Employer Contributions
@@ -229,9 +231,15 @@ For an employee with monthly income I, age group G, and ceiling C:
 - Free and open-source (MIT licence)
 - Core tools work without sign-up or an account
 - Email is only requested when a user asks for a CPF resource or report
-- Rates sourced from CPF Board publications
+- Rates sourced from CPF Board publications, effective ${CPF_DATA_AS_OF_LABEL}
 - Calculation logic is fully transparent and verifiable on GitHub
 - Not affiliated with the CPF Board or any government agency
+
+## Currency and Disclaimer
+
+All rates, ceilings, retirement sums and Basic Healthcare Sum values on this page are effective ${CPF_DATA_AS_OF_LABEL}.
+
+SimplyCPF is independent and not affiliated with the CPF Board. Figures are estimates based on published rates and are not financial advice.
 `;
 
 export async function GET(): Promise<Response> {

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -2,24 +2,28 @@
 
 import { ThemeProvider } from "next-themes";
 import type { PropsWithChildren } from "react";
+import { I18nProvider } from "react-aria-components";
 import { CpfStoreProvider } from "@/providers/cpf-store-provider";
 
 /**
  * Root providers component.
  *
  * Wraps the application with all context providers:
+ * - I18nProvider pinning React Aria (HeroUI) formatting to en-SG
  * - ThemeProvider for dark/light mode
  * - CpfStoreProvider for the Zustand store
  */
-export const Providers = ({ children }: PropsWithChildren) => {
+export function Providers({ children }: PropsWithChildren) {
   return (
-    <ThemeProvider
-      attribute="class"
-      defaultTheme="system"
-      enableSystem
-      disableTransitionOnChange
-    >
-      <CpfStoreProvider>{children}</CpfStoreProvider>
-    </ThemeProvider>
+    <I18nProvider locale="en-SG">
+      <ThemeProvider
+        attribute="class"
+        defaultTheme="system"
+        enableSystem
+        disableTransitionOnChange
+      >
+        <CpfStoreProvider>{children}</CpfStoreProvider>
+      </ThemeProvider>
+    </I18nProvider>
   );
-};
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -18,6 +18,26 @@ export const formatCurrency = (
   }).format(numericValue);
 };
 
+/**
+ * Group-separated number, pinned to en-SG.
+ *
+ * Prefer this over a bare `value.toLocaleString()`, which follows the server's
+ * or the visitor's default locale. That renders differently on the server and
+ * the client, a hydration mismatch, and in the SEO content blocks, indexed
+ * text that differs from what a reader sees.
+ */
+export const formatNumber = (
+  value: number | string,
+  decimalPlaces = 0,
+): string => {
+  const numericValue = typeof value === "string" ? Number(value) : value;
+
+  return new Intl.NumberFormat("en-SG", {
+    minimumFractionDigits: decimalPlaces,
+    maximumFractionDigits: decimalPlaces,
+  }).format(numericValue);
+};
+
 export const formatDate = (
   date: Date | string,
   dateFormat = "dd MMMM yyyy",

--- a/src/lib/get-cpf-cheat-sheet-data.ts
+++ b/src/lib/get-cpf-cheat-sheet-data.ts
@@ -16,6 +16,7 @@ import {
   permanentResidentYear1Rates,
   permanentResidentYear2Rates,
 } from "@/data/permanent-resident-rates";
+import { formatNumber } from "@/lib/format";
 
 export interface CheatSheetSection {
   title: string;
@@ -31,7 +32,7 @@ export interface CheatSheetData {
 }
 
 const formatPct = (value: number) => `${(value * 100).toFixed(1)}%`;
-const formatCurrency = (value: number) => `S$${value.toLocaleString()}`;
+const formatCurrency = (value: number) => `S$${formatNumber(value)}`;
 
 export function getCpfCheatSheetData(): CheatSheetData {
   return {


### PR DESCRIPTION
- Add `formatNumber` and route 33 bare `toLocaleString()` call sites through it; they followed the server's or visitor's default locale, so server and client rendered different strings and indexed SEO text could differ from what a reader sees
- Pin React Aria formatting to `en-SG` via `I18nProvider`
- Carry the effective date and disclaimer in `cpf-rates.md` and `llms.txt`; the latter had no date at all despite being the canonical export for LLMs

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
