### PR TITLE
Add shared UI primitives and OA accrued interest calculation

### DIFF
--- a/src/components/shared/section-header.tsx
+++ b/src/components/shared/section-header.tsx
@@ -1,0 +1,54 @@
+import { cn } from "@heroui/react";
+import type { ReactNode } from "react";
+
+interface EyebrowProps {
+  children: ReactNode;
+  withDot?: boolean;
+  className?: string;
+}
+
+/**
+ * Mono uppercase eyebrow label — the "machine produced" register. Optionally
+ * led by the live-data forest dot.
+ */
+export function Eyebrow({ children, withDot, className }: EyebrowProps) {
+  return (
+    <span className={cn("flex items-center gap-2", className)}>
+      {withDot && (
+        <span aria-hidden className="size-1.5 rounded-full bg-accent" />
+      )}
+      <span className="font-mono text-[10.5px] text-accent uppercase tracking-[0.13em]">
+        {children}
+      </span>
+    </span>
+  );
+}
+
+interface PageHeaderProps {
+  eyebrow: string;
+  title: string;
+  lede?: string;
+  actions?: ReactNode;
+}
+
+/** Screen heading: muted mono eyebrow, display title, optional lede + actions. */
+export function PageHeader({ eyebrow, title, lede, actions }: PageHeaderProps) {
+  return (
+    <header className="flex flex-col gap-2">
+      <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">
+        {eyebrow}
+      </span>
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <h1 className="text-balance font-semibold text-4xl tracking-tight">
+          {title}
+        </h1>
+        {actions}
+      </div>
+      {lede && (
+        <p className="max-w-[76ch] text-pretty text-base text-muted leading-relaxed">
+          {lede}
+        </p>
+      )}
+    </header>
+  );
+}

--- a/src/components/shared/section-header.tsx
+++ b/src/components/shared/section-header.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@heroui/react";
-import type { ReactNode } from "react";
+import type { ReactElement, ReactNode } from "react";
 
 interface EyebrowProps {
   children: ReactNode;
@@ -11,7 +11,11 @@ interface EyebrowProps {
  * Mono uppercase eyebrow label — the "machine produced" register. Optionally
  * led by the live-data forest dot.
  */
-export function Eyebrow({ children, withDot, className }: EyebrowProps) {
+export function Eyebrow({
+  children,
+  withDot,
+  className,
+}: EyebrowProps): ReactElement {
   return (
     <span className={cn("flex items-center gap-2", className)}>
       {withDot && (
@@ -32,7 +36,12 @@ interface PageHeaderProps {
 }
 
 /** Screen heading: muted mono eyebrow, display title, optional lede + actions. */
-export function PageHeader({ eyebrow, title, lede, actions }: PageHeaderProps) {
+export function PageHeader({
+  eyebrow,
+  title,
+  lede,
+  actions,
+}: PageHeaderProps): ReactElement {
   return (
     <header className="flex flex-col gap-2">
       <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">

--- a/src/components/shared/split-bar.tsx
+++ b/src/components/shared/split-bar.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@heroui/react";
+import type { ReactElement } from "react";
 
 export type SplitBarColor =
   | "chart-1"
@@ -57,7 +58,7 @@ export function SplitBar({
   size = "md",
   formatValue,
   className,
-}: SplitBarProps) {
+}: SplitBarProps): ReactElement | null {
   const total = segments.reduce((sum, segment) => sum + segment.value, 0);
   if (total <= 0) return null;
 
@@ -96,7 +97,7 @@ export function SplitBar({
           {showLabels && (
             <span
               className={cn(
-                "overflow-hidden whitespace-nowrap pl-3 font-medium text-[12.5px]",
+                "overflow-hidden whitespace-nowrap pl-2 font-medium text-[12.5px]",
                 TEXT_CLASSES[segment.color],
               )}
             >

--- a/src/components/shared/split-bar.tsx
+++ b/src/components/shared/split-bar.tsx
@@ -1,0 +1,110 @@
+import { cn } from "@heroui/react";
+
+export type SplitBarColor =
+  | "chart-1"
+  | "chart-2"
+  | "chart-3"
+  | "chart-4"
+  | "chart-5"
+  | "track";
+
+export interface SplitBarSegment {
+  label: string;
+  value: number;
+  color: SplitBarColor;
+}
+
+interface SplitBarProps {
+  segments: SplitBarSegment[];
+  /** sm: 20px silent bar · md: 36px labelled · lg: 38px labelled hero bar */
+  size?: "sm" | "md" | "lg";
+  formatValue?: (value: number) => string;
+  className?: string;
+}
+
+const HEIGHTS: Record<NonNullable<SplitBarProps["size"]>, number> = {
+  sm: 20,
+  md: 36,
+  lg: 38,
+};
+
+const FILL_CLASSES: Record<SplitBarColor, string> = {
+  "chart-1": "bg-chart-1",
+  "chart-2": "bg-chart-2",
+  "chart-3": "bg-chart-3",
+  "chart-4": "bg-chart-4",
+  "chart-5": "bg-chart-5",
+  track: "bg-foreground/10",
+};
+
+/** Light fills carry ink text; dark fills carry paper text. */
+const TEXT_CLASSES: Record<SplitBarColor, string> = {
+  "chart-1": "text-background",
+  "chart-2": "text-background",
+  "chart-3": "text-foreground",
+  "chart-4": "text-background",
+  "chart-5": "text-background",
+  track: "text-foreground",
+};
+
+/**
+ * A proportional multi-segment bar with labels inside the segments.
+ * HeroUI has no segmented bar (Meter/ProgressBar are single-fill), so this
+ * renders the brand's fixed chart encoding directly from the chart tokens.
+ */
+export function SplitBar({
+  segments,
+  size = "md",
+  formatValue,
+  className,
+}: SplitBarProps) {
+  const total = segments.reduce((sum, segment) => sum + segment.value, 0);
+  if (total <= 0) return null;
+
+  const description = segments
+    .map(
+      (segment) =>
+        `${segment.label} ${
+          formatValue
+            ? formatValue(segment.value)
+            : `${Math.round((segment.value / total) * 100)}%`
+        }`,
+    )
+    .join(", ");
+  const showLabels = size !== "sm";
+
+  return (
+    <div
+      role="img"
+      aria-label={description}
+      className={cn(
+        "flex w-full overflow-hidden",
+        size === "sm" ? "rounded-[5px]" : "rounded-lg",
+        className,
+      )}
+      style={{ height: HEIGHTS[size] }}
+    >
+      {segments.map((segment) => (
+        <div
+          key={segment.label}
+          className={cn(
+            "flex min-w-0 items-center overflow-hidden",
+            FILL_CLASSES[segment.color],
+          )}
+          style={{ width: `${(segment.value / total) * 100}%` }}
+        >
+          {showLabels && (
+            <span
+              className={cn(
+                "overflow-hidden whitespace-nowrap pl-3 font-medium text-[12.5px]",
+                TEXT_CLASSES[segment.color],
+              )}
+            >
+              {segment.label}
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/shared/stat-band.tsx
+++ b/src/components/shared/stat-band.tsx
@@ -1,0 +1,37 @@
+export interface StatBandItem {
+  label: string;
+  value: string;
+  note?: string;
+}
+
+interface StatBandProps {
+  items: StatBandItem[];
+}
+
+/**
+ * Full-bleed reference strip of headline figures on the band surface —
+ * the "numbers are the hero" close to a screen.
+ */
+export function StatBand({ items }: StatBandProps) {
+  return (
+    <section className="border-border border-t bg-band">
+      <dl className="container mx-auto grid grid-cols-2 gap-8 px-4 py-6 md:grid-cols-5">
+        {items.map((item) => (
+          <div key={item.label} className="flex flex-col gap-1">
+            <dt className="font-mono text-[10px] text-muted uppercase tracking-[0.12em]">
+              {item.label}
+            </dt>
+            <dd className="flex flex-col">
+              <span className="font-semibold text-xl tracking-tight">
+                {item.value}
+              </span>
+              {item.note && (
+                <span className="text-muted text-xs">{item.note}</span>
+              )}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}

--- a/src/components/shared/stat-band.tsx
+++ b/src/components/shared/stat-band.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from "react";
+
 export interface StatBandItem {
   label: string;
   value: string;
@@ -12,12 +14,12 @@ interface StatBandProps {
  * Full-bleed reference strip of headline figures on the band surface —
  * the "numbers are the hero" close to a screen.
  */
-export function StatBand({ items }: StatBandProps) {
+export function StatBand({ items }: StatBandProps): ReactElement {
   return (
     <section className="border-border border-t bg-band">
       <dl className="container mx-auto grid grid-cols-2 gap-8 px-4 py-6 md:grid-cols-5">
         {items.map((item) => (
-          <div key={item.label} className="flex flex-col gap-1">
+          <div key={item.label} className="flex flex-col gap-2">
             <dt className="font-mono text-[10px] text-muted uppercase tracking-[0.12em]">
               {item.label}
             </dt>

--- a/src/components/shared/wordmark.tsx
+++ b/src/components/shared/wordmark.tsx
@@ -1,0 +1,45 @@
+import { cn } from "@heroui/react";
+import Link from "next/link";
+
+interface WordmarkProps {
+  size?: "sm" | "md";
+  className?: string;
+}
+
+/**
+ * SimplyCPF wordmark: the name with an ink rule beneath it, broken by one
+ * forest segment. The rule is the line drawn under a figure that has been
+ * checked — never render the wordmark without it.
+ */
+export function Wordmark({ size = "md", className }: WordmarkProps) {
+  const isSmall = size === "sm";
+
+  return (
+    <Link
+      href="/"
+      className={cn("flex flex-col items-start", className)}
+      style={{ gap: isSmall ? 3 : 4 }}
+    >
+      <span
+        className="font-semibold tracking-tight"
+        style={{ fontSize: isSmall ? 13 : 17.5, letterSpacing: "-0.02em" }}
+      >
+        SimplyCPF
+      </span>
+      <span
+        aria-hidden
+        className="flex w-full"
+        style={{ gap: isSmall ? 2.5 : 3 }}
+      >
+        <span
+          className="flex-1 rounded-full bg-foreground"
+          style={{ height: isSmall ? 2 : 2.5 }}
+        />
+        <span
+          className="rounded-full bg-accent"
+          style={{ height: isSmall ? 2 : 2.5, width: isSmall ? 16 : 22 }}
+        />
+      </span>
+    </Link>
+  );
+}

--- a/src/components/shared/wordmark.tsx
+++ b/src/components/shared/wordmark.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@heroui/react";
 import Link from "next/link";
+import type { ReactElement } from "react";
 
 interface WordmarkProps {
   size?: "sm" | "md";
@@ -11,7 +12,10 @@ interface WordmarkProps {
  * forest segment. The rule is the line drawn under a figure that has been
  * checked — never render the wordmark without it.
  */
-export function Wordmark({ size = "md", className }: WordmarkProps) {
+export function Wordmark({
+  size = "md",
+  className,
+}: WordmarkProps): ReactElement {
   const isSmall = size === "sm";
 
   return (

--- a/src/lib/__tests__/calculate-accrued-interest.test.ts
+++ b/src/lib/__tests__/calculate-accrued-interest.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { calculateAccruedInterest } from "@/lib/calculate-accrued-interest";
+
+describe("calculateAccruedInterest", () => {
+  it.each([
+    { oaUsed: 150_000, years: 5, expectedTotal: 150_000 * 1.025 ** 5 },
+    { oaUsed: 250_000, years: 10, expectedTotal: 250_000 * 1.025 ** 10 },
+    { oaUsed: 400_000, years: 20, expectedTotal: 400_000 * 1.025 ** 20 },
+  ])("compounds $oaUsed at the OA floor rate over $years years", ({
+    oaUsed,
+    years,
+    expectedTotal,
+  }) => {
+    const result = calculateAccruedInterest(oaUsed, years);
+
+    expect(result.totalOwed).toBeCloseTo(expectedTotal, 6);
+    expect(result.accruedInterest).toBeCloseTo(expectedTotal - oaUsed, 6);
+    expect(result.yearlyRows).toHaveLength(years);
+    expect(result.yearlyRows.at(-1)?.cumulativeInterest).toBeCloseTo(
+      expectedTotal - oaUsed,
+      6,
+    );
+  });
+
+  it("builds strictly increasing cumulative interest rows", () => {
+    const { yearlyRows } = calculateAccruedInterest(250_000, 10);
+
+    for (let index = 1; index < yearlyRows.length; index++) {
+      expect(yearlyRows[index].cumulativeInterest).toBeGreaterThan(
+        yearlyRows[index - 1].cumulativeInterest,
+      );
+    }
+  });
+
+  it("rounds the illustrative sale price to the nearest $10,000", () => {
+    expect(calculateAccruedInterest(250_000, 10).illustrativeSalePrice).toBe(
+      600_000,
+    );
+    expect(calculateAccruedInterest(151_000, 10).illustrativeSalePrice).toBe(
+      360_000,
+    );
+  });
+
+  it("returns no accrued interest for zero years held", () => {
+    const result = calculateAccruedInterest(250_000, 0);
+
+    expect(result.totalOwed).toBe(250_000);
+    expect(result.accruedInterest).toBe(0);
+    expect(result.yearlyRows).toHaveLength(0);
+    expect(result.cashProceeds).toBe(result.illustrativeSalePrice - 250_000);
+  });
+
+  it("caps the refund at the sale price when the tab exceeds it", () => {
+    const result = calculateAccruedInterest(100, 40, 0.5);
+
+    expect(result.totalOwed).toBeGreaterThan(result.illustrativeSalePrice);
+    expect(result.refundToCpf).toBe(result.illustrativeSalePrice);
+    expect(result.cashProceeds).toBe(0);
+  });
+
+  it("clamps negative principal and fractional years", () => {
+    const negative = calculateAccruedInterest(-500, 10);
+    expect(negative.principal).toBe(0);
+    expect(negative.totalOwed).toBe(0);
+
+    const fractional = calculateAccruedInterest(100_000, 7.9);
+    expect(fractional.yearsHeld).toBe(7);
+  });
+
+  it("accepts a custom interest rate", () => {
+    const result = calculateAccruedInterest(100_000, 1, 0.04);
+
+    expect(result.totalOwed).toBeCloseTo(104_000, 6);
+  });
+});

--- a/src/lib/calculate-accrued-interest.ts
+++ b/src/lib/calculate-accrued-interest.ts
@@ -1,0 +1,63 @@
+import { CPF_INTEREST_FLOOR_RATES } from "@/constants/cpf-interest-rates";
+
+export interface AccruedInterestYearRow {
+  year: number;
+  cumulativeInterest: number;
+}
+
+export interface AccruedInterestResult {
+  principal: number;
+  yearsHeld: number;
+  /** Principal plus accrued interest — refundable to CPF on sale */
+  totalOwed: number;
+  accruedInterest: number;
+  yearlyRows: AccruedInterestYearRow[];
+  /** Illustrative sale price: 2.4× principal, rounded to the nearest $10k */
+  illustrativeSalePrice: number;
+  refundToCpf: number;
+  cashProceeds: number;
+}
+
+/**
+ * OA money used for a property keeps a running tab: the interest it would
+ * have earned at the OA floor rate had it stayed. On sale, the principal plus
+ * that accrued interest returns to CPF before any cash is paid out. A refund
+ * to yourself, not a penalty — but it changes what a sale actually pays out.
+ *
+ * Models a single lump-sum withdrawal compounding yearly. Monthly instalments,
+ * valuation limits, appreciation, fees and post-55 rules are not modelled.
+ */
+export function calculateAccruedInterest(
+  oaUsed: number,
+  yearsHeld: number,
+  rate: number = CPF_INTEREST_FLOOR_RATES.OA / 100,
+): AccruedInterestResult {
+  const principal = Math.max(0, oaUsed);
+  const years = Math.max(0, Math.floor(yearsHeld));
+
+  const totalOwed = principal * (1 + rate) ** years;
+  const accruedInterest = totalOwed - principal;
+
+  const yearlyRows: AccruedInterestYearRow[] = [];
+  for (let year = 1; year <= years; year++) {
+    yearlyRows.push({
+      year,
+      cumulativeInterest: principal * (1 + rate) ** year - principal,
+    });
+  }
+
+  const illustrativeSalePrice = Math.round((principal * 2.4) / 10_000) * 10_000;
+  const refundToCpf = Math.min(totalOwed, illustrativeSalePrice);
+  const cashProceeds = Math.max(0, illustrativeSalePrice - totalOwed);
+
+  return {
+    principal,
+    yearsHeld: years,
+    totalOwed,
+    accruedInterest,
+    yearlyRows,
+    illustrativeSalePrice,
+    refundToCpf,
+    cashProceeds,
+  };
+}


### PR DESCRIPTION
- Add shared primitives where HeroUI has no equivalent: `SplitBar` (segmented proportional bars), `SectionHeader`, `StatBand` and `Wordmark`
- Add `calculate-accrued-interest.ts` for OA used on a home, with tests

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
