### PR TITLE
Restore product UI with HeroUI OSS and Pro primitives

### DIFF
--- a/src/app/(main)/about/page.tsx
+++ b/src/app/(main)/about/page.tsx
@@ -1,4 +1,4 @@
-import { Accordion, buttonVariants, Card, cn } from "@heroui/react";
+import { Accordion, Alert, buttonVariants, Card, cn } from "@heroui/react";
 import { ArrowRight02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { Metadata } from "next";
@@ -125,18 +125,17 @@ const About = () => {
           </Card.Content>
         </Card>
 
-        <Card className="border-orange-200 bg-orange-50">
-          <Card.Header>
-            <Card.Title>Important Disclaimer</Card.Title>
-          </Card.Header>
-          <Card.Content>
-            <p className="mb-4">
+        <Alert status="warning">
+          <Alert.Indicator />
+          <Alert.Content className="flex flex-col gap-4">
+            <Alert.Title>Important Disclaimer</Alert.Title>
+            <Alert.Description>
               This calculator is an independent tool to help with CPF
               contribution calculations. It is not affiliated with, endorsed by,
               or connected to the Central Provident Fund Board (CPF Board),
               Ministry of Manpower (MOM), or any government agency.
-            </p>
-            <p>
+            </Alert.Description>
+            <p className="text-sm">
               All rates are sourced from CPF Board publications and the
               calculation logic is open for anyone to verify. For official CPF
               matters, always refer to the{" "}
@@ -150,8 +149,8 @@ const About = () => {
               </a>{" "}
               or contact CPF Board directly.
             </p>
-          </Card.Content>
-        </Card>
+          </Alert.Content>
+        </Alert>
 
         <Card data-content-block="faq">
           <Card.Header>

--- a/src/components/cpf-life/cpf-life-content.tsx
+++ b/src/components/cpf-life/cpf-life-content.tsx
@@ -11,6 +11,7 @@ import {
   ToggleButton,
   ToggleButtonGroup,
 } from "@heroui/react";
+import { BarChart } from "@heroui-pro/react";
 import { type Key, useEffect, useMemo, useState } from "react";
 import { shallow } from "zustand/shallow";
 import { useCpfStore } from "@/hooks/use-cpf-store";
@@ -41,24 +42,31 @@ function monthly(value: number): string {
   return formatCurrency(value, 0);
 }
 
-interface MiniBarsProps {
+interface PlanBarsProps {
   values: number[];
   max: number;
-  color: string;
+  fill: string;
+  label: string;
 }
 
-function MiniBars({ values, max, color }: MiniBarsProps) {
+function PlanBars({ values, max, fill, label }: PlanBarsProps) {
+  const data = [
+    { age: "65", payout: values[0] ?? 0 },
+    { age: "75", payout: values[1] ?? 0 },
+    { age: "85", payout: values[2] ?? 0 },
+  ];
+
   return (
-    <div aria-hidden className="flex h-16 items-end gap-2">
-      {values.map((value, index) => (
-        <div
-          className={cn("flex-1 rounded-t-sm", color)}
-          // biome-ignore lint/suspicious/noArrayIndexKey: bars are positional (65/75/85)
-          key={index}
-          style={{ height: `${Math.max(8, (value / max) * 64)}px` }}
-        />
-      ))}
-    </div>
+    <BarChart
+      aria-label={`${label} payout at ages 65, 75, and 85`}
+      data={data}
+      height={64}
+      margin={{ bottom: 0, left: 0, right: 0, top: 0 }}
+    >
+      <BarChart.XAxis dataKey="age" hide />
+      <BarChart.YAxis domain={[0, max]} hide />
+      <BarChart.Bar dataKey="payout" fill={fill} radius={[4, 4, 0, 0]} />
+    </BarChart>
   );
 }
 
@@ -121,6 +129,7 @@ export function CpfLifeContent() {
     {
       name: "Standard",
       swatch: "bg-chart-1",
+      fill: "var(--chart-1)",
       value: standard,
       suffix: "/month, flat",
       bars: [standard, standard, standard],
@@ -130,6 +139,7 @@ export function CpfLifeContent() {
     {
       name: "Escalating",
       swatch: "bg-chart-2",
+      fill: "var(--chart-2)",
       value: escalating,
       suffix: "/month, +2% a year",
       bars: [escalating, escalating75, escalating85],
@@ -143,6 +153,7 @@ export function CpfLifeContent() {
     {
       name: "Basic",
       swatch: "bg-chart-3",
+      fill: "var(--chart-3)",
       value: basic,
       suffix: "/month, can fall",
       bars: [basic, basic, basic85],
@@ -274,7 +285,12 @@ export function CpfLifeContent() {
                 </span>
                 <span className="text-muted text-xs">{plan.suffix}</span>
               </p>
-              <MiniBars color={plan.swatch} max={maxBar} values={plan.bars} />
+              <PlanBars
+                fill={plan.fill}
+                label={plan.name}
+                max={maxBar}
+                values={plan.bars}
+              />
               <div className="flex items-baseline justify-between gap-2 font-mono text-[10.5px] text-muted">
                 {plan.ages.map((age) => (
                   <span key={age}>{age}</span>

--- a/src/components/interest-rates/rate-tiles.tsx
+++ b/src/components/interest-rates/rate-tiles.tsx
@@ -1,4 +1,5 @@
-import { Card, cn } from "@heroui/react";
+import { cn } from "@heroui/react";
+import { KPI } from "@heroui-pro/react";
 import { CPF_INTEREST_FLOOR_RATES } from "@/constants/cpf-interest-rates";
 import {
   CPF_ADDITIONAL_SENIOR_INTEREST_CAP,
@@ -6,39 +7,42 @@ import {
   CPF_EXTRA_INTEREST_RATE,
   CPF_OA_EXTRA_INTEREST_CAP,
 } from "@/constants/cpf-interest-tiers";
-import { formatCurrency, formatPercentage } from "@/lib/format";
+import { formatCurrency } from "@/lib/format";
 
 const extraRate = CPF_EXTRA_INTEREST_RATE;
 
 interface Tile {
   label: string;
-  value: string;
+  value: number;
   note: string;
   accent?: boolean;
+  signDisplay?: "always" | "auto";
 }
 
 const tiles: Tile[] = [
   {
     label: "Ordinary Account",
-    value: formatPercentage(CPF_INTEREST_FLOOR_RATES.OA / 100),
+    value: CPF_INTEREST_FLOOR_RATES.OA / 100,
     note: "A legislated floor rate, applied per year on the balance.",
   },
   {
     label: "SA · MA · RA",
-    value: formatPercentage(CPF_INTEREST_FLOOR_RATES.SMRA / 100),
+    value: CPF_INTEREST_FLOOR_RATES.SMRA / 100,
     note: "Floor rate. Otherwise pegged to the 10-year SGS yield plus 1%.",
   },
   {
     label: "Extra, under 55",
-    value: `+${formatPercentage(extraRate)}`,
+    value: extraRate,
     note: `On the first ${formatCurrency(CPF_EXTRA_INTEREST_CAP, 0)} combined, of which at most ${formatCurrency(CPF_OA_EXTRA_INTEREST_CAP, 0)} from OA.`,
     accent: true,
+    signDisplay: "always",
   },
   {
     label: "Extra, 55 and over",
-    value: `+${formatPercentage(extraRate * 2)}`,
-    note: `On the first ${formatCurrency(CPF_ADDITIONAL_SENIOR_INTEREST_CAP, 0)}, then +${formatPercentage(extraRate, { decimalPlaces: 0 })} on the next ${formatCurrency(CPF_ADDITIONAL_SENIOR_INTEREST_CAP, 0)}.`,
+    value: extraRate * 2,
+    note: `On the first ${formatCurrency(CPF_ADDITIONAL_SENIOR_INTEREST_CAP, 0)}, then +${(extraRate * 100).toFixed(0)}% on the next ${formatCurrency(CPF_ADDITIONAL_SENIOR_INTEREST_CAP, 0)}.`,
     accent: true,
+    signDisplay: "always",
   },
 ];
 
@@ -47,32 +51,41 @@ export function RateTiles() {
   return (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
       {tiles.map((tile) => (
-        <Card
+        <KPI
           key={tile.label}
-          className={cn(tile.accent && "border-accent/25 bg-accent/10")}
+          className={cn(
+            "gap-2",
+            tile.accent && "border-accent/25 bg-accent/10",
+          )}
         >
-          <Card.Content className="flex flex-col gap-2">
-            <span
+          <KPI.Header>
+            <KPI.Title
               className={cn(
                 "font-mono text-[10px] uppercase tracking-[0.12em]",
                 tile.accent ? "text-accent" : "text-muted",
               )}
             >
               {tile.label}
-            </span>
-            <span
+            </KPI.Title>
+          </KPI.Header>
+          <KPI.Content>
+            <KPI.Value
               className={cn(
                 "font-semibold text-[30px] leading-none tracking-tight",
                 tile.accent ? "text-accent" : "text-foreground",
               )}
-            >
-              {tile.value}
-            </span>
-            <Card.Description className="text-[12.5px] text-muted leading-relaxed">
-              {tile.note}
-            </Card.Description>
-          </Card.Content>
-        </Card>
+              locale="en-SG"
+              maximumFractionDigits={2}
+              minimumFractionDigits={tile.accent ? 0 : 2}
+              signDisplay={tile.signDisplay}
+              style="percent"
+              value={tile.value}
+            />
+          </KPI.Content>
+          <KPI.Footer className="text-[12.5px] text-muted leading-relaxed">
+            {tile.note}
+          </KPI.Footer>
+        </KPI>
       ))}
     </div>
   );

--- a/src/components/investments/cpf-investment-comparison.tsx
+++ b/src/components/investments/cpf-investment-comparison.tsx
@@ -1,18 +1,21 @@
 "use client";
 
-import { Card, Label, NumberField, Slider, Table } from "@heroui/react";
-import posthog from "posthog-js";
-import { useState } from "react";
 import {
-  CartesianGrid,
-  Legend,
-  Line,
-  LineChart,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+  Alert,
+  Card,
+  Chip,
+  Label,
+  NumberField,
+  Slider,
+  Table,
+  ToggleButton,
+  ToggleButtonGroup,
+} from "@heroui/react";
+import { LineChart } from "@heroui-pro/react";
+import posthog from "posthog-js";
+import type { Key } from "react";
+import { useState } from "react";
+import { Legend } from "recharts";
 import { CPF_INTEREST_FLOOR_RATES } from "@/constants/cpf-interest-rates";
 import { formatCurrency, formatPercentage } from "@/lib/format";
 
@@ -24,48 +27,54 @@ interface InvestmentScenario {
   color: string;
 }
 
+const RISK_CHIP_COLOR = {
+  Low: "success",
+  Medium: "warning",
+  High: "danger",
+} as const;
+
 const INVESTMENT_SCENARIOS: InvestmentScenario[] = [
   {
     name: "CPF OA",
     rate: CPF_INTEREST_FLOOR_RATES.OA,
     description: "Ordinary Account, fixed floor rate",
     riskLevel: "Low",
-    color: "#3b82f6",
+    color: "var(--chart-1)",
   },
   {
     name: "CPF SA/MA/RA",
     rate: CPF_INTEREST_FLOOR_RATES.SMRA,
     description: "Special, MediSave & Retirement Accounts",
     riskLevel: "Low",
-    color: "#10b981",
+    color: "var(--chart-2)",
   },
   {
     name: "Singapore Bonds",
     rate: 3.5,
     description: "Government bonds and corporate bonds",
     riskLevel: "Low",
-    color: "#f59e0b",
+    color: "var(--chart-5)",
   },
   {
     name: "STI ETF",
     rate: 6.0,
     description: "Straits Times Index ETF (historical avg)",
     riskLevel: "Medium",
-    color: "#8b5cf6",
+    color: "var(--chart-3)",
   },
   {
     name: "Global Equity ETF",
     rate: 7.5,
     description: "MSCI World Index (historical avg)",
     riskLevel: "Medium",
-    color: "#ec4899",
+    color: "var(--chart-4)",
   },
   {
     name: "Tech Stocks",
     rate: 10.0,
     description: "Technology sector equities (high volatility)",
     riskLevel: "High",
-    color: "#ef4444",
+    color: "var(--danger)",
   },
 ];
 
@@ -74,13 +83,25 @@ interface ChartDataPoint {
   [key: string]: number;
 }
 
-const calculateGrowth = (
+function calculateGrowth(
   principal: number,
   rate: number,
   years: number,
-): number => {
+): number {
   return principal * (1 + rate / 100) ** years;
-};
+}
+
+function RiskChip({
+  riskLevel,
+}: {
+  riskLevel: InvestmentScenario["riskLevel"];
+}) {
+  return (
+    <Chip color={RISK_CHIP_COLOR[riskLevel]} size="sm" variant="soft">
+      <Chip.Label>{riskLevel}</Chip.Label>
+    </Chip>
+  );
+}
 
 export function CPFInvestmentComparison() {
   const [principal, setPrincipal] = useState<number>(50000);
@@ -91,22 +112,27 @@ export function CPFInvestmentComparison() {
     "STI ETF",
   ]);
 
-  const toggleScenario = (name: string) => {
-    setSelectedScenarios((prev) => {
-      const isRemoving = prev.includes(name);
-      const next = isRemoving
-        ? prev.filter((s) => s !== name)
-        : [...prev, name].slice(0, 4);
+  const handleScenarioSelection = (keys: Set<Key> | "all") => {
+    if (keys === "all") return;
+
+    const next = [...keys].map(String);
+    if (next.length > 4) return;
+
+    const added = next.find((name) => !selectedScenarios.includes(name));
+    const removed = selectedScenarios.find((name) => !next.includes(name));
+    const toggled = added ?? removed;
+
+    if (toggled) {
       posthog.capture("investment_scenario_toggled", {
-        scenario: name,
-        action: isRemoving ? "removed" : "added",
+        scenario: toggled,
+        action: added ? "added" : "removed",
         active_scenarios: next,
       });
-      return next;
-    });
+    }
+
+    setSelectedScenarios(next);
   };
 
-  // Generate chart data
   const chartData: ChartDataPoint[] = Array.from(
     { length: years + 1 },
     (_, year) => {
@@ -124,35 +150,37 @@ export function CPFInvestmentComparison() {
     },
   );
 
-  // Calculate final values for comparison table
   const finalValues = INVESTMENT_SCENARIOS.map((scenario) => ({
     ...scenario,
     finalValue: calculateGrowth(principal, scenario.rate, years),
     totalGain: calculateGrowth(principal, scenario.rate, years) - principal,
   }));
 
+  const activeScenarios = INVESTMENT_SCENARIOS.filter((s) =>
+    selectedScenarios.includes(s.name),
+  );
+
   return (
     <div className="flex flex-col gap-6">
-      {/* Disclaimer Banner */}
-      <Card className="border-amber-200 bg-amber-50">
-        <Card.Content>
-          <p className="text-amber-900 text-sm">
-            <strong>Disclaimer:</strong> The investment returns shown are
-            historical averages and do not guarantee future performance.
-            Investments carry risks including potential loss of principal. CPF
-            savings are guaranteed by the Singapore Government. Always consult a
-            financial adviser before making investment decisions.
-          </p>
-        </Card.Content>
-      </Card>
+      <Alert status="warning">
+        <Alert.Indicator />
+        <Alert.Content>
+          <Alert.Title>Disclaimer</Alert.Title>
+          <Alert.Description>
+            The investment returns shown are historical averages and do not
+            guarantee future performance. Investments carry risks including
+            potential loss of principal. CPF savings are guaranteed by the
+            Singapore Government. Always consult a financial adviser before
+            making investment decisions.
+          </Alert.Description>
+        </Alert.Content>
+      </Alert>
 
-      {/* Calculator Section */}
       <Card>
         <Card.Header>
           <Card.Title>Investment Returns Calculator</Card.Title>
         </Card.Header>
         <Card.Content className="flex flex-col gap-6">
-          {/* Input Controls */}
           <div className="grid gap-6 md:grid-cols-2">
             <NumberField
               className="flex flex-col gap-2"
@@ -193,100 +221,89 @@ export function CPFInvestmentComparison() {
             </Slider>
           </div>
 
-          {/* Scenario Selection */}
           <div className="flex flex-col gap-4">
             <Label>Select Investment Scenarios (max 4 for chart):</Label>
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            <ToggleButtonGroup
+              isDetached
+              aria-label="Investment scenarios"
+              className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3"
+              selectedKeys={new Set(selectedScenarios)}
+              selectionMode="multiple"
+              onSelectionChange={handleScenarioSelection}
+            >
               {INVESTMENT_SCENARIOS.map((scenario) => (
-                <button
+                <ToggleButton
                   key={scenario.name}
-                  type="button"
-                  onClick={() => toggleScenario(scenario.name)}
-                  aria-pressed={selectedScenarios.includes(scenario.name)}
-                  className={`rounded-lg border-2 p-4 text-left transition-all ${
-                    selectedScenarios.includes(scenario.name)
-                      ? "border-blue-500 bg-blue-50"
-                      : "border-zinc-200 hover:border-zinc-300"
-                  }`}
+                  className="h-auto flex-col items-stretch gap-2 p-4 text-left"
+                  id={scenario.name}
                 >
                   <div className="flex items-start justify-between gap-2">
-                    <div className="flex-1">
-                      <p className="mb-2 font-semibold text-sm">
+                    <div className="flex flex-col gap-2">
+                      <span className="font-semibold text-sm">
                         {scenario.name}
-                      </p>
-                      <p className="text-xs text-zinc-600">
+                      </span>
+                      <span className="text-muted text-xs">
                         {formatPercentage(scenario.rate / 100, {
                           decimalPlaces: 1,
                         })}{" "}
                         p.a.
-                      </p>
+                      </span>
                     </div>
-                    <span
-                      className={`rounded px-2 py-1 text-xs ${
-                        scenario.riskLevel === "Low"
-                          ? "bg-green-100 text-green-700"
-                          : scenario.riskLevel === "Medium"
-                            ? "bg-amber-100 text-amber-700"
-                            : "bg-red-100 text-red-700"
-                      }`}
-                    >
-                      {scenario.riskLevel}
-                    </span>
+                    <RiskChip riskLevel={scenario.riskLevel} />
                   </div>
-                </button>
+                </ToggleButton>
               ))}
-            </div>
+            </ToggleButtonGroup>
           </div>
 
-          {/* Growth Chart */}
           <div
             role="img"
             aria-label="Investment growth comparison chart showing projected returns over time for selected scenarios"
+            className="flex flex-col gap-4"
           >
-            <h3 className="mb-4 font-semibold text-lg">Growth Over Time</h3>
-            <ResponsiveContainer width="100%" height={400}>
-              <LineChart data={chartData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis
-                  dataKey="year"
-                  label={{
-                    value: "Years",
-                    position: "insideBottom",
-                    offset: -5,
-                  }}
-                />
-                <YAxis
-                  label={{
-                    value: "Value (S$)",
-                    angle: -90,
-                    position: "insideLeft",
-                  }}
-                  tickFormatter={(value) => formatCurrency(value, 0)}
-                />
-                <Tooltip
-                  formatter={(value) => formatCurrency(Number(value))}
-                  labelFormatter={(label) => `Year ${label}`}
-                />
-                <Legend />
-                {INVESTMENT_SCENARIOS.filter((s) =>
-                  selectedScenarios.includes(s.name),
-                ).map((scenario) => (
-                  <Line
-                    key={scenario.name}
-                    type="monotone"
-                    dataKey={scenario.name}
-                    stroke={scenario.color}
-                    strokeWidth={2}
-                    dot={false}
+            <h3 className="font-semibold text-lg">Growth Over Time</h3>
+            <LineChart data={chartData} height={400}>
+              <LineChart.Grid strokeDasharray="3 3" />
+              <LineChart.XAxis
+                dataKey="year"
+                label={{
+                  value: "Years",
+                  position: "insideBottom",
+                  offset: -5,
+                }}
+              />
+              <LineChart.YAxis
+                label={{
+                  value: "Value (S$)",
+                  angle: -90,
+                  position: "insideLeft",
+                }}
+                tickFormatter={(value) => formatCurrency(value, 0)}
+              />
+              <LineChart.Tooltip
+                content={
+                  <LineChart.TooltipContent
+                    labelFormatter={(label) => `Year ${label}`}
+                    valueFormatter={(value) => formatCurrency(Number(value))}
                   />
-                ))}
-              </LineChart>
-            </ResponsiveContainer>
+                }
+              />
+              <Legend />
+              {activeScenarios.map((scenario) => (
+                <LineChart.Line
+                  key={scenario.name}
+                  type="monotone"
+                  dataKey={scenario.name}
+                  stroke={scenario.color}
+                  strokeWidth={2}
+                  dot={false}
+                />
+              ))}
+            </LineChart>
           </div>
         </Card.Content>
       </Card>
 
-      {/* Comparison Table */}
       <Card>
         <Card.Header>
           <Card.Title>Final Value Comparison ({years} years)</Card.Title>
@@ -325,17 +342,7 @@ export function CPFInvestmentComparison() {
                           })}
                         </Table.Cell>
                         <Table.Cell>
-                          <span
-                            className={`rounded px-2 py-1 text-xs ${
-                              item.riskLevel === "Low"
-                                ? "bg-green-100 text-green-700"
-                                : item.riskLevel === "Medium"
-                                  ? "bg-amber-100 text-amber-700"
-                                  : "bg-red-100 text-red-700"
-                            }`}
-                          >
-                            {item.riskLevel}
-                          </span>
+                          <RiskChip riskLevel={item.riskLevel} />
                         </Table.Cell>
                         <Table.Cell className="text-right font-semibold">
                           {formatCurrency(item.finalValue)}
@@ -344,13 +351,13 @@ export function CPFInvestmentComparison() {
                           {formatCurrency(item.totalGain)}
                         </Table.Cell>
                         <Table.Cell
-                          className={`text-right font-medium ${
+                          className={
                             gainVsCpfOa > 0
-                              ? "text-green-600"
+                              ? "text-right font-medium text-success"
                               : gainVsCpfOa < 0
-                                ? "text-red-600"
-                                : ""
-                          }`}
+                                ? "text-right font-medium text-danger"
+                                : "text-right font-medium"
+                          }
                         >
                           {gainVsCpfOa > 0 ? "+" : ""}
                           {formatCurrency(gainVsCpfOa)}
@@ -365,51 +372,46 @@ export function CPFInvestmentComparison() {
         </Card.Content>
       </Card>
 
-      {/* Key Considerations */}
       <Card>
         <Card.Header>
           <Card.Title>Key Considerations</Card.Title>
         </Card.Header>
         <Card.Content className="flex flex-col gap-4">
-          <div className="flex flex-col gap-4 text-sm">
-            <div className="rounded-lg border border-blue-200 bg-blue-50 p-4">
-              <h4 className="mb-2 font-semibold text-blue-900">
-                CPF Advantages
-              </h4>
-              <ul className="flex flex-col gap-2 text-blue-800">
-                <li>• Guaranteed returns by Singapore Government</li>
-                <li>• No market volatility risk</li>
-                <li>• Tax-free interest earnings</li>
-                <li>• Automatic monthly contributions from salary</li>
-              </ul>
-            </div>
+          <Alert status="accent">
+            <Alert.Indicator />
+            <Alert.Content>
+              <Alert.Title>CPF Advantages</Alert.Title>
+              <Alert.Description>
+                Guaranteed returns by Singapore Government. No market volatility
+                risk. Tax-free interest earnings. Automatic monthly
+                contributions from salary.
+              </Alert.Description>
+            </Alert.Content>
+          </Alert>
 
-            <div className="rounded-lg border border-amber-200 bg-amber-50 p-4">
-              <h4 className="mb-2 font-semibold text-amber-900">
-                Investment Advantages
-              </h4>
-              <ul className="flex flex-col gap-2 text-amber-800">
-                <li>• Potential for higher returns (with higher risk)</li>
-                <li>• More liquidity and flexibility</li>
-                <li>• Diversification opportunities</li>
-                <li>• Can invest beyond CPF limits</li>
-              </ul>
-            </div>
+          <Alert status="warning">
+            <Alert.Indicator />
+            <Alert.Content>
+              <Alert.Title>Investment Advantages</Alert.Title>
+              <Alert.Description>
+                Potential for higher returns (with higher risk). More liquidity
+                and flexibility. Diversification opportunities. Can invest
+                beyond CPF limits.
+              </Alert.Description>
+            </Alert.Content>
+          </Alert>
 
-            <div className="rounded-lg border border-red-200 bg-red-50 p-4">
-              <h4 className="mb-2 font-semibold text-red-900">
-                Investment Risks
-              </h4>
-              <ul className="flex flex-col gap-2 text-red-800">
-                <li>• Market volatility can lead to losses</li>
-                <li>• No guaranteed returns</li>
-                <li>• Requires knowledge and active management</li>
-                <li>
-                  • Historical returns do not guarantee future performance
-                </li>
-              </ul>
-            </div>
-          </div>
+          <Alert status="danger">
+            <Alert.Indicator />
+            <Alert.Content>
+              <Alert.Title>Investment Risks</Alert.Title>
+              <Alert.Description>
+                Market volatility can lead to losses. No guaranteed returns.
+                Requires knowledge and active management. Historical returns do
+                not guarantee future performance.
+              </Alert.Description>
+            </Alert.Content>
+          </Alert>
         </Card.Content>
       </Card>
     </div>

--- a/src/components/layout/__tests__/header.test.tsx
+++ b/src/components/layout/__tests__/header.test.tsx
@@ -4,6 +4,42 @@ import { Header } from "../header";
 
 const push = vi.fn();
 
+vi.mock("@heroui/react", async () => {
+  const actual =
+    await vi.importActual<typeof import("@heroui/react")>("@heroui/react");
+
+  return {
+    ...actual,
+    Button: function ButtonMock({
+      children,
+      ...props
+    }: {
+      children: React.ReactNode;
+      "aria-label"?: string;
+    }) {
+      return (
+        <button type="button" {...props}>
+          {children}
+        </button>
+      );
+    },
+    Link: function LinkMock({
+      children,
+      href,
+      ...props
+    }: {
+      children: React.ReactNode;
+      href?: string;
+    }) {
+      return (
+        <a href={href} {...props}>
+          {children}
+        </a>
+      );
+    },
+  };
+});
+
 vi.mock("@heroui-pro/react", () => {
   function Segment({ children }: { children: React.ReactNode }) {
     return <div role="radiogroup">{children}</div>;
@@ -15,7 +51,60 @@ vi.mock("@heroui-pro/react", () => {
   }) {
     return <button type="button">{children}</button>;
   };
-  return { Segment };
+
+  function Sheet({ children }: { children: React.ReactNode }) {
+    return <div data-testid="mobile-nav-sheet">{children}</div>;
+  }
+  Sheet.Trigger = function SheetTrigger({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) {
+    return <>{children}</>;
+  };
+  Sheet.Backdrop = function SheetBackdrop({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) {
+    return <div>{children}</div>;
+  };
+  Sheet.Content = function SheetContent({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) {
+    return <div>{children}</div>;
+  };
+  Sheet.Dialog = function SheetDialog({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) {
+    return <div>{children}</div>;
+  };
+  Sheet.Header = function SheetHeader({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) {
+    return <div>{children}</div>;
+  };
+  Sheet.Heading = function SheetHeading({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) {
+    return <h2>{children}</h2>;
+  };
+  Sheet.Body = function SheetBody({ children }: { children: React.ReactNode }) {
+    return <div>{children}</div>;
+  };
+  Sheet.CloseTrigger = function SheetCloseTrigger() {
+    return <button type="button">Close</button>;
+  };
+
+  return { Segment, Sheet };
 });
 
 vi.mock("next/navigation", () => ({
@@ -67,6 +156,13 @@ describe("Header", () => {
     ]) {
       expect(screen.getAllByText(label).length).toBeGreaterThan(0);
     }
+  });
+
+  it("renders the mobile menu trigger", () => {
+    render(<Header />);
+
+    expect(screen.getByLabelText("Open menu")).toBeTruthy();
+    expect(screen.getByTestId("mobile-nav-sheet")).toBeTruthy();
   });
 
   it("renders the theme toggle", () => {

--- a/src/components/layout/__tests__/header.test.tsx
+++ b/src/components/layout/__tests__/header.test.tsx
@@ -26,13 +26,16 @@ vi.mock("@heroui/react", async () => {
     Link: function LinkMock({
       children,
       href,
-      ...props
+      className,
+      "aria-current": ariaCurrent,
     }: {
       children: React.ReactNode;
       href?: string;
+      className?: string;
+      "aria-current"?: string;
     }) {
       return (
-        <a href={href} {...props}>
+        <a href={href} className={className} aria-current={ariaCurrent}>
           {children}
         </a>
       );

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,5 +1,5 @@
+import { Link } from "@heroui/react";
 import type { Route } from "next";
-import Link from "next/link";
 import { Wordmark } from "@/components/shared/wordmark";
 
 const primaryLinks: { href: Route; label: string }[] = [
@@ -27,11 +27,7 @@ export function Footer() {
           </p>
           <nav aria-label="Footer" className="flex items-center gap-4 text-sm">
             {primaryLinks.map((link) => (
-              <Link
-                key={link.href}
-                href={link.href}
-                className="text-link hover:text-foreground"
-              >
+              <Link key={link.href} href={link.href}>
                 {link.label}
               </Link>
             ))}
@@ -45,22 +41,22 @@ export function Footer() {
               {moreLinks.map((link) => (
                 <Link
                   key={link.href}
+                  className="text-muted text-xs"
                   href={link.href}
-                  className="text-muted text-xs hover:text-foreground"
                 >
                   {link.label}
                 </Link>
               ))}
             </nav>
           </div>
-          <a
+          <Link
+            className="text-muted text-xs"
             href="https://github.com/ruchernchong/simplycpf"
-            target="_blank"
             rel="noopener noreferrer"
-            className="text-muted text-xs hover:text-foreground"
+            target="_blank"
           >
             GitHub · open source
-          </a>
+          </Link>
         </div>
       </div>
     </footer>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Segment } from "@heroui-pro/react";
+import { Button, cn, Link } from "@heroui/react";
+import { Segment, Sheet } from "@heroui-pro/react";
+import { Menu } from "lucide-react";
 import type { Route } from "next";
-import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import ThemeToggle from "@/components/layout/theme-toggle";
@@ -34,6 +35,8 @@ const referenceNavItems: NavItem[] = [
   { href: "/cpf-cheat-sheet" as Route, label: "Cheat sheet" },
   { href: "/cpf-check" as Route, label: "Check" },
 ];
+
+const allNavItems = [...questionNavItems, ...referenceNavItems];
 
 function NavSegment({ items }: { items: NavItem[] }) {
   const pathname = usePathname();
@@ -77,6 +80,62 @@ function InputSummary() {
   );
 }
 
+function MobileNav() {
+  const pathname = usePathname();
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="lg:hidden">
+      <Sheet isOpen={isOpen} onOpenChange={setIsOpen} placement="right">
+        <Sheet.Trigger>
+          <Button
+            aria-label="Open menu"
+            isIconOnly
+            size="sm"
+            variant="secondary"
+          >
+            <Menu aria-hidden className="size-4" />
+          </Button>
+        </Sheet.Trigger>
+        <Sheet.Backdrop>
+          <Sheet.Content className="w-full max-w-xs">
+            <Sheet.Dialog>
+              <Sheet.Header className="flex items-center justify-between gap-4">
+                <Sheet.Heading>Menu</Sheet.Heading>
+                <Sheet.CloseTrigger />
+              </Sheet.Header>
+              <Sheet.Body>
+                <nav aria-label="Main, compact" className="flex flex-col gap-2">
+                  {allNavItems.map((item) => {
+                    const isActive = pathname === item.href;
+
+                    return (
+                      <Link
+                        aria-current={isActive ? "page" : undefined}
+                        className={cn(
+                          "rounded-lg px-4 py-2 text-sm no-underline",
+                          isActive
+                            ? "bg-accent/10 font-medium text-accent"
+                            : "text-muted",
+                        )}
+                        href={item.href}
+                        key={item.href}
+                        onPress={() => setIsOpen(false)}
+                      >
+                        {item.label}
+                      </Link>
+                    );
+                  })}
+                </nav>
+              </Sheet.Body>
+            </Sheet.Dialog>
+          </Sheet.Content>
+        </Sheet.Backdrop>
+      </Sheet>
+    </div>
+  );
+}
+
 export function Header() {
   return (
     <header className="sticky top-0 z-50 w-full border-border border-b bg-background">
@@ -98,36 +157,9 @@ export function Header() {
         <div className="flex items-center gap-4">
           <InputSummary />
           <ThemeToggle />
+          <MobileNav />
         </div>
       </div>
-
-      <nav
-        aria-label="Main, compact"
-        className="flex gap-4 overflow-x-auto px-4 pb-2 lg:hidden"
-      >
-        {[...questionNavItems, ...referenceNavItems].map((item) => (
-          <MobileNavLink key={item.href} item={item} />
-        ))}
-      </nav>
     </header>
-  );
-}
-
-function MobileNavLink({ item }: { item: NavItem }) {
-  const pathname = usePathname();
-  const isActive = pathname === item.href;
-
-  return (
-    <Link
-      href={item.href}
-      aria-current={isActive ? "page" : undefined}
-      className={
-        isActive
-          ? "whitespace-nowrap font-medium text-foreground text-sm"
-          : "whitespace-nowrap text-muted text-sm"
-      }
-    >
-      {item.label}
-    </Link>
   );
 }

--- a/src/components/pdf/cpf-cheat-sheet-pdf.tsx
+++ b/src/components/pdf/cpf-cheat-sheet-pdf.tsx
@@ -1,15 +1,9 @@
 import { Document, Page, StyleSheet, Text, View } from "@react-pdf/renderer";
+import { BRAND } from "@/lib/brand";
 import {
   type CheatSheetSection,
   getCpfCheatSheetData,
 } from "@/lib/get-cpf-cheat-sheet-data";
-
-const TEAL = "#0f766e";
-const SLATE_900 = "#0f172a";
-const SLATE_700 = "#334155";
-const SLATE_500 = "#64748b";
-const SLATE_100 = "#e2e8f0";
-const SLATE_50 = "#f8fafc";
 
 const styles = StyleSheet.create({
   page: {
@@ -18,16 +12,16 @@ const styles = StyleSheet.create({
     paddingHorizontal: 32,
     fontFamily: "Helvetica",
     fontSize: 9,
-    color: SLATE_900,
+    color: BRAND.ink,
   },
   header: {
     borderBottomWidth: 2,
-    borderBottomColor: TEAL,
+    borderBottomColor: BRAND.forest,
     paddingBottom: 12,
     marginBottom: 20,
   },
   overline: {
-    color: TEAL,
+    color: BRAND.forest,
     fontSize: 9,
     textTransform: "uppercase",
     letterSpacing: 1.1,
@@ -39,7 +33,7 @@ const styles = StyleSheet.create({
     marginBottom: 6,
   },
   subtitle: {
-    color: SLATE_700,
+    color: BRAND.textBody,
     lineHeight: 1.5,
   },
   section: {
@@ -51,47 +45,47 @@ const styles = StyleSheet.create({
     marginBottom: 4,
   },
   sectionDescription: {
-    color: SLATE_500,
+    color: BRAND.textSecondary,
     lineHeight: 1.4,
     marginBottom: 8,
   },
   table: {
     borderWidth: 1,
-    borderColor: SLATE_100,
+    borderColor: BRAND.bone,
     borderRadius: 6,
     overflow: "hidden",
   },
   row: {
     flexDirection: "row",
     borderBottomWidth: 1,
-    borderBottomColor: SLATE_100,
+    borderBottomColor: BRAND.bone,
   },
   headerRow: {
-    backgroundColor: SLATE_50,
+    backgroundColor: BRAND.card,
   },
   cell: {
     flex: 1,
     paddingVertical: 6,
     paddingHorizontal: 8,
     borderRightWidth: 1,
-    borderRightColor: SLATE_100,
+    borderRightColor: BRAND.bone,
   },
   lastCell: {
     borderRightWidth: 0,
   },
   headerCellText: {
     fontFamily: "Helvetica-Bold",
-    color: SLATE_700,
+    color: BRAND.textBody,
   },
   bodyCellText: {
-    color: SLATE_900,
+    color: BRAND.ink,
   },
   footer: {
     position: "absolute",
     bottom: 18,
     left: 32,
     right: 32,
-    color: SLATE_500,
+    color: BRAND.textSecondary,
     textAlign: "center",
     fontSize: 8,
   },

--- a/src/components/pdf/cpf-results-pdf.tsx
+++ b/src/components/pdf/cpf-results-pdf.tsx
@@ -8,36 +8,32 @@ import {
   View,
 } from "@react-pdf/renderer";
 import type { PdfData } from "@/components/pdf/download-pdf";
+import { BRAND } from "@/lib/brand";
 
-const TEAL = "#0d9488";
-const SLATE_600 = "#475569";
-const SLATE_400 = "#94a3b8";
-const SLATE_100 = "#f1f5f9";
-
-const PIE_COLOURS = ["#0d9488", "#14b8a6", "#5eead4"];
+const CHART_COLOURS = [BRAND.chart1, BRAND.chart2, BRAND.chart3];
 
 const styles = StyleSheet.create({
   page: {
     padding: 40,
     fontFamily: "Helvetica",
     fontSize: 10,
-    color: "#1e293b",
+    color: BRAND.ink,
   },
   header: {
     marginBottom: 24,
     borderBottomWidth: 2,
-    borderBottomColor: TEAL,
+    borderBottomColor: BRAND.forest,
     paddingBottom: 12,
   },
   title: {
     fontSize: 20,
     fontFamily: "Helvetica-Bold",
-    color: TEAL,
+    color: BRAND.forest,
     marginBottom: 4,
   },
   subtitle: {
     fontSize: 10,
-    color: SLATE_400,
+    color: BRAND.textSubtle,
   },
   section: {
     marginBottom: 20,
@@ -46,24 +42,24 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontFamily: "Helvetica-Bold",
     marginBottom: 10,
-    color: "#1e293b",
+    color: BRAND.ink,
   },
   row: {
     flexDirection: "row",
     justifyContent: "space-between",
     paddingVertical: 6,
     borderBottomWidth: 1,
-    borderBottomColor: SLATE_100,
+    borderBottomColor: BRAND.bone,
   },
   rowLabel: {
-    color: SLATE_600,
+    color: BRAND.textSecondary,
   },
   rowValue: {
     fontFamily: "Helvetica-Bold",
   },
   rowValueAccent: {
     fontFamily: "Helvetica-Bold",
-    color: TEAL,
+    color: BRAND.forest,
   },
   comparisonGrid: {
     flexDirection: "row",
@@ -72,13 +68,13 @@ const styles = StyleSheet.create({
   },
   comparisonCard: {
     flex: 1,
-    backgroundColor: SLATE_100,
+    backgroundColor: BRAND.bone,
     padding: 10,
     borderRadius: 4,
   },
   comparisonLabel: {
     fontSize: 9,
-    color: SLATE_600,
+    color: BRAND.textSecondary,
     marginBottom: 4,
   },
   comparisonValue: {
@@ -86,10 +82,10 @@ const styles = StyleSheet.create({
     fontFamily: "Helvetica-Bold",
   },
   positive: {
-    color: "#059669",
+    color: BRAND.forest,
   },
   negative: {
-    color: "#d97706",
+    color: BRAND.clay,
   },
   distributionRow: {
     flexDirection: "row",
@@ -108,7 +104,7 @@ const styles = StyleSheet.create({
     left: 40,
     right: 40,
     fontSize: 8,
-    color: SLATE_400,
+    color: BRAND.textSubtle,
     textAlign: "center",
   },
   ceilingTimeline: {
@@ -117,7 +113,7 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     marginBottom: 12,
     padding: 8,
-    backgroundColor: SLATE_100,
+    backgroundColor: BRAND.bone,
     borderRadius: 4,
   },
   ceilingValue: {
@@ -126,7 +122,7 @@ const styles = StyleSheet.create({
   },
   ceilingLabel: {
     fontSize: 8,
-    color: SLATE_600,
+    color: BRAND.textSecondary,
   },
 });
 
@@ -187,7 +183,7 @@ function PieChart({ data, size = 100 }: PieChartProps) {
 
     paths.push({
       d,
-      fill: PIE_COLOURS[index % PIE_COLOURS.length],
+      fill: CHART_COLOURS[index % CHART_COLOURS.length],
     });
 
     startAngle = endAngle;
@@ -280,9 +276,9 @@ export function CpfResultsPdf({ data }: CpfResultsPdfProps) {
                 </Text>
                 <Text style={styles.ceilingLabel}>Pre-Sept 2023</Text>
               </View>
-              <Text style={{ color: SLATE_400 }}>→</Text>
+              <Text style={{ color: BRAND.textSubtle }}>→</Text>
               <View>
-                <Text style={[styles.ceilingValue, { color: TEAL }]}>
+                <Text style={[styles.ceilingValue, { color: BRAND.forest }]}>
                   {formatCurrency(data.ceilingComparison.currentCeiling, 0)}
                 </Text>
                 <Text style={styles.ceilingLabel}>Current</Text>
@@ -310,8 +306,8 @@ export function CpfResultsPdf({ data }: CpfResultsPdfProps) {
                   style={[
                     styles.comparisonValue,
                     data.ceilingComparison.cpfImpact >= 0
-                      ? { color: TEAL }
-                      : { color: SLATE_400 },
+                      ? { color: BRAND.forest }
+                      : { color: BRAND.textSubtle },
                   ]}
                 >
                   {formatDifference(data.ceilingComparison.cpfImpact)}

--- a/src/components/projection/balance-growth-chart.tsx
+++ b/src/components/projection/balance-growth-chart.tsx
@@ -1,16 +1,8 @@
 "use client";
 
 import { Card } from "@heroui/react";
-import {
-  Area,
-  AreaChart,
-  CartesianGrid,
-  Legend,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import { AreaChart } from "@heroui-pro/react";
+import { Legend } from "recharts";
 import { formatCurrency } from "@/lib/format";
 import type { ProjectionResult } from "@/types";
 
@@ -18,12 +10,12 @@ interface BalanceGrowthChartProps {
   yearlyBalances: ProjectionResult["yearlyBalances"];
 }
 
-const accountColours = {
-  oa: "#2563eb",
-  sa: "#0f766e",
-  ma: "#f59e0b",
-  ra: "#7c3aed",
-} as const;
+const accountSeries = [
+  { key: "oa", name: "OA", color: "var(--chart-1)" },
+  { key: "sa", name: "SA", color: "var(--chart-2)" },
+  { key: "ma", name: "MA", color: "var(--chart-3)" },
+  { key: "ra", name: "RA", color: "var(--chart-4)" },
+] as const;
 
 export default function BalanceGrowthChart({
   yearlyBalances,
@@ -46,50 +38,33 @@ export default function BalanceGrowthChart({
           role="img"
           aria-label="Stacked area chart showing projected CPF balances across OA, SA, MA and RA by age"
         >
-          <ResponsiveContainer width="100%" height={360}>
-            <AreaChart data={chartData}>
-              <CartesianGrid strokeDasharray="3 3" vertical={false} />
-              <XAxis dataKey="age" />
-              <YAxis tickFormatter={(value) => formatCurrency(value, 0)} />
-              <Tooltip
-                formatter={(value) => formatCurrency(Number(value), 0)}
-                labelFormatter={(value) => `Age ${value}`}
-              />
-              <Legend />
-              <Area
-                dataKey="oa"
-                name="OA"
+          <AreaChart data={chartData} height={360}>
+            <AreaChart.Grid strokeDasharray="3 3" vertical={false} />
+            <AreaChart.XAxis dataKey="age" />
+            <AreaChart.YAxis
+              tickFormatter={(value) => formatCurrency(value, 0)}
+            />
+            <AreaChart.Tooltip
+              content={
+                <AreaChart.TooltipContent
+                  labelFormatter={(value) => `Age ${value}`}
+                  valueFormatter={(value) => formatCurrency(Number(value), 0)}
+                />
+              }
+            />
+            <Legend />
+            {accountSeries.map((series) => (
+              <AreaChart.Area
+                key={series.key}
+                dataKey={series.key}
+                name={series.name}
                 stackId="cpf"
-                stroke={accountColours.oa}
-                fill={accountColours.oa}
+                stroke={series.color}
+                fill={series.color}
                 fillOpacity={0.7}
               />
-              <Area
-                dataKey="sa"
-                name="SA"
-                stackId="cpf"
-                stroke={accountColours.sa}
-                fill={accountColours.sa}
-                fillOpacity={0.7}
-              />
-              <Area
-                dataKey="ma"
-                name="MA"
-                stackId="cpf"
-                stroke={accountColours.ma}
-                fill={accountColours.ma}
-                fillOpacity={0.7}
-              />
-              <Area
-                dataKey="ra"
-                name="RA"
-                stackId="cpf"
-                stroke={accountColours.ra}
-                fill={accountColours.ra}
-                fillOpacity={0.7}
-              />
-            </AreaChart>
-          </ResponsiveContainer>
+            ))}
+          </AreaChart>
         </div>
       </Card.Content>
     </Card>

--- a/src/components/projection/cpf-life-estimate.tsx
+++ b/src/components/projection/cpf-life-estimate.tsx
@@ -1,4 +1,5 @@
-import { Card } from "@heroui/react";
+import { Card, Surface } from "@heroui/react";
+import { KPI } from "@heroui-pro/react";
 import { formatCurrency } from "@/lib/format";
 import type { ProjectionResult } from "@/types";
 
@@ -46,25 +47,42 @@ export default function CpfLifeEstimate({ result }: CpfLifeEstimateProps) {
         {result.cpfLifeEstimate.standardMonthly > 0 ? (
           <div className="grid gap-4 lg:grid-cols-2">
             {payoutOptions.map((option) => (
-              <div
-                key={option.label}
-                className="rounded-lg border border-border bg-surface-tertiary/30 p-4"
-              >
-                <p className="font-medium text-foreground text-sm">
-                  {option.label}
-                </p>
-                <p className="pb-2 font-semibold text-2xl text-foreground">
-                  {formatCurrency(option.value, 0)}
-                  <span className="pl-2 font-normal text-muted text-sm">
-                    per month
-                  </span>
-                </p>
-                <p className="text-muted text-sm">{option.description}</p>
-              </div>
+              <KPI className="gap-2" key={option.label}>
+                <KPI.Header>
+                  <KPI.Title className="font-medium text-foreground text-sm">
+                    {option.label}
+                  </KPI.Title>
+                </KPI.Header>
+                <KPI.Content>
+                  <KPI.Value
+                    className="font-semibold text-2xl text-foreground"
+                    currency="SGD"
+                    locale="en-SG"
+                    maximumFractionDigits={0}
+                    style="currency"
+                    value={option.value}
+                  >
+                    {(formatted) => (
+                      <span className="flex items-baseline gap-2">
+                        <span>{formatted}</span>
+                        <span className="font-normal text-muted text-sm">
+                          per month
+                        </span>
+                      </span>
+                    )}
+                  </KPI.Value>
+                </KPI.Content>
+                <KPI.Footer className="text-muted text-sm">
+                  {option.description}
+                </KPI.Footer>
+              </KPI>
             ))}
           </div>
         ) : (
-          <div className="rounded-lg border border-border bg-surface-tertiary/30 p-4">
+          <Surface
+            className="flex flex-col gap-2 rounded-lg p-4"
+            variant="tertiary"
+          >
             <p className="font-medium text-foreground text-sm">
               Your projected RA balance is still below the S$60,000 threshold
               used for the current CPF LIFE estimate.
@@ -73,7 +91,7 @@ export default function CpfLifeEstimate({ result }: CpfLifeEstimateProps) {
               Try extending the projection horizon, increasing income, or adding
               a top-up to see how the estimate changes.
             </p>
-          </div>
+          </Surface>
         )}
       </Card.Content>
     </Card>

--- a/src/components/projection/projection-content.tsx
+++ b/src/components/projection/projection-content.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Button, Card } from "@heroui/react";
+import { Button, Card, Skeleton } from "@heroui/react";
+import { KPI, KPIGroup } from "@heroui-pro/react";
 import dynamic from "next/dynamic";
 import {
   parseAsInteger,
@@ -12,7 +13,6 @@ import { useState, useTransition } from "react";
 import { calculateCpfProjection } from "@/lib/calculate-cpf-projection";
 import { convertBirthDateToAge } from "@/lib/convert-birth-date-to-age";
 import { formatDateInput, isValidDateFormat } from "@/lib/date-utils";
-import { formatCurrency } from "@/lib/format";
 import type { ProjectionParams } from "@/types";
 import CpfLifeEstimate from "./cpf-life-estimate";
 import MilestoneCards from "./milestone-cards";
@@ -27,7 +27,7 @@ const BalanceGrowthChart = dynamic(() => import("./balance-growth-chart"), {
         <Card.Title>Balance Growth Over Time</Card.Title>
       </Card.Header>
       <Card.Content>
-        <div className="h-[360px] animate-pulse rounded-lg bg-zinc-200" />
+        <Skeleton className="h-[360px] w-full rounded-lg" />
       </Card.Content>
     </Card>
   ),
@@ -195,34 +195,61 @@ export default function ProjectionContent() {
                 {linkCopied ? "Link copied" : "Copy share link"}
               </Button>
             </div>
-            <div className="grid gap-4 md:grid-cols-3">
-              <Card>
-                <Card.Header>
-                  <Card.Description>
+            <KPIGroup className="w-full md:grid md:grid-cols-3 md:gap-4">
+              <KPI className="gap-2">
+                <KPI.Header>
+                  <KPI.Title className="font-mono text-[10px] text-muted uppercase tracking-[0.12em]">
                     Projected CPF at age {finalBalance.age}
-                  </Card.Description>
-                  <Card.Title className="text-2xl">
-                    {formatCurrency(getTotalBalance(finalBalance.balances), 0)}
-                  </Card.Title>
-                </Card.Header>
-              </Card>
-              <Card>
-                <Card.Header>
-                  <Card.Description>Total contributions</Card.Description>
-                  <Card.Title className="text-2xl">
-                    {formatCurrency(result.totalContributed, 0)}
-                  </Card.Title>
-                </Card.Header>
-              </Card>
-              <Card>
-                <Card.Header>
-                  <Card.Description>Total interest earned</Card.Description>
-                  <Card.Title className="text-2xl">
-                    {formatCurrency(result.totalInterestEarned, 0)}
-                  </Card.Title>
-                </Card.Header>
-              </Card>
-            </div>
+                  </KPI.Title>
+                </KPI.Header>
+                <KPI.Content>
+                  <KPI.Value
+                    className="font-semibold text-[26px] tracking-tight"
+                    currency="SGD"
+                    locale="en-SG"
+                    maximumFractionDigits={0}
+                    style="currency"
+                    value={getTotalBalance(finalBalance.balances)}
+                  />
+                </KPI.Content>
+              </KPI>
+              <KPIGroup.Separator className="md:hidden" />
+              <KPI className="gap-2">
+                <KPI.Header>
+                  <KPI.Title className="font-mono text-[10px] text-muted uppercase tracking-[0.12em]">
+                    Total contributions
+                  </KPI.Title>
+                </KPI.Header>
+                <KPI.Content>
+                  <KPI.Value
+                    className="font-semibold text-[26px] tracking-tight"
+                    currency="SGD"
+                    locale="en-SG"
+                    maximumFractionDigits={0}
+                    style="currency"
+                    value={result.totalContributed}
+                  />
+                </KPI.Content>
+              </KPI>
+              <KPIGroup.Separator className="md:hidden" />
+              <KPI className="gap-2">
+                <KPI.Header>
+                  <KPI.Title className="font-mono text-[10px] text-muted uppercase tracking-[0.12em]">
+                    Total interest earned
+                  </KPI.Title>
+                </KPI.Header>
+                <KPI.Content>
+                  <KPI.Value
+                    className="font-semibold text-[26px] tracking-tight"
+                    currency="SGD"
+                    locale="en-SG"
+                    maximumFractionDigits={0}
+                    style="currency"
+                    value={result.totalInterestEarned}
+                  />
+                </KPI.Content>
+              </KPI>
+            </KPIGroup>
 
             <BalanceGrowthChart yearlyBalances={result.yearlyBalances} />
             <MilestoneCards result={result} />

--- a/src/components/retirement-readiness/readiness-score-form.tsx
+++ b/src/components/retirement-readiness/readiness-score-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Button, cn } from "@heroui/react";
+import { Alert, Button, Label } from "@heroui/react";
+import { RadioButtonGroup } from "@heroui-pro/react";
 import { useState } from "react";
 import ReadinessScoreResult from "@/components/retirement-readiness/readiness-score-result";
 import { READINESS_QUESTIONS } from "@/data/retirement-readiness-questions";
@@ -37,51 +38,47 @@ export default function ReadinessScoreForm() {
     <div className="flex flex-col gap-6">
       <form className="flex flex-col gap-6" onSubmit={handleCalculate}>
         {READINESS_QUESTIONS.map((question) => (
-          <fieldset key={question.key} className="flex flex-col gap-4">
-            <legend className="font-semibold text-foreground">
+          <RadioButtonGroup
+            key={question.key}
+            className="gap-4 md:grid-cols-2"
+            layout="grid"
+            name={question.key}
+            value={answers[question.key]}
+            onChange={(value) => {
+              setAnswers((current) => ({
+                ...current,
+                [question.key]: value as ReadinessAnswers[typeof question.key],
+              }));
+              setFormError(null);
+            }}
+          >
+            <Label className="col-span-full font-semibold text-foreground">
               {question.label}
-            </legend>
-            <div className="grid gap-4 md:grid-cols-2">
-              {question.options.map((choice) => {
-                const isSelected = answers[question.key] === choice.value;
-
-                return (
-                  <label
-                    key={choice.value}
-                    className={cn(
-                      "flex cursor-pointer flex-col gap-2 rounded-xl border p-4 transition-colors",
-                      isSelected
-                        ? "border-accent bg-accent/5"
-                        : "border-border hover:border-accent/40",
-                    )}
-                  >
-                    <input
-                      type="radio"
-                      name={question.key}
-                      value={choice.value}
-                      checked={isSelected}
-                      onChange={() =>
-                        setAnswers((current) => ({
-                          ...current,
-                          [question.key]: choice.value,
-                        }))
-                      }
-                      className="sr-only"
-                    />
-                    <span className="font-medium text-foreground">
-                      {choice.label}
-                    </span>
-                    <span className="text-muted text-sm">
-                      {choice.description}
-                    </span>
-                  </label>
-                );
-              })}
-            </div>
-          </fieldset>
+            </Label>
+            {question.options.map((choice) => (
+              <RadioButtonGroup.Item key={choice.value} value={choice.value}>
+                <RadioButtonGroup.Indicator />
+                <RadioButtonGroup.ItemContent className="flex flex-col gap-2">
+                  <span className="font-medium text-foreground">
+                    {choice.label}
+                  </span>
+                  <span className="text-muted text-sm">
+                    {choice.description}
+                  </span>
+                </RadioButtonGroup.ItemContent>
+              </RadioButtonGroup.Item>
+            ))}
+          </RadioButtonGroup>
         ))}
 
-        {formError ? <p className="text-danger text-sm">{formError}</p> : null}
+        {formError ? (
+          <Alert status="danger">
+            <Alert.Indicator />
+            <Alert.Content>
+              <Alert.Description>{formError}</Alert.Description>
+            </Alert.Content>
+          </Alert>
+        ) : null}
         <Button type="submit" size="lg">
           Calculate my readiness score
         </Button>

--- a/src/components/seo/cpf-age-specific-block.tsx
+++ b/src/components/seo/cpf-age-specific-block.tsx
@@ -1,5 +1,5 @@
-import { Card } from "@heroui/react";
-import Link from "next/link";
+import { buttonVariants, Card, cn, Link, Surface } from "@heroui/react";
+import { KPI } from "@heroui-pro/react";
 import { formatPercentage } from "@/lib/format";
 import type { AgeGroup } from "@/types";
 
@@ -7,7 +7,7 @@ interface CpfAgeSpecificBlockProps {
   ageGroup: AgeGroup;
 }
 
-const CpfAgeSpecificBlock = ({ ageGroup }: CpfAgeSpecificBlockProps) => {
+function CpfAgeSpecificBlock({ ageGroup }: CpfAgeSpecificBlockProps) {
   const employeeRate = ageGroup.contributionRate.employee;
   const employerRate = ageGroup.contributionRate.employer;
   const totalRate = employeeRate + employerRate;
@@ -17,6 +17,24 @@ const CpfAgeSpecificBlock = ({ ageGroup }: CpfAgeSpecificBlockProps) => {
   const currentYear = new Date().getFullYear();
   const birthYear = currentYear - representativeAge;
   const birthDate = `${birthYear}-01-01`;
+
+  const rateTiles = [
+    {
+      label: "Employee Rate",
+      value: employeeRate,
+      accent: false,
+    },
+    {
+      label: "Employer Rate",
+      value: employerRate,
+      accent: false,
+    },
+    {
+      label: "Total Rate",
+      value: totalRate,
+      accent: true,
+    },
+  ];
 
   return (
     <section
@@ -37,63 +55,66 @@ const CpfAgeSpecificBlock = ({ ageGroup }: CpfAgeSpecificBlockProps) => {
         </Card.Header>
         <Card.Content className="flex flex-col gap-6">
           <div className="grid grid-cols-3 gap-4">
-            <div className="rounded-lg bg-surface-tertiary p-4">
-              <p className="mb-1 text-muted text-sm">Employee Rate</p>
-              <p className="font-bold font-mono text-2xl text-foreground">
-                {formatPercentage(employeeRate, { decimalPlaces: 1 })}
-              </p>
-            </div>
-            <div className="rounded-lg bg-surface-tertiary p-4">
-              <p className="mb-1 text-muted text-sm">Employer Rate</p>
-              <p className="font-bold font-mono text-2xl text-foreground">
-                {formatPercentage(employerRate, { decimalPlaces: 1 })}
-              </p>
-            </div>
-            <div className="rounded-lg bg-accent/10 p-4">
-              <p className="mb-1 text-accent-foreground text-sm">Total Rate</p>
-              <p className="font-bold font-mono text-2xl text-accent">
-                {formatPercentage(totalRate, { decimalPlaces: 1 })}
-              </p>
-            </div>
+            {rateTiles.map((tile) => (
+              <KPI
+                className={cn(
+                  "gap-2",
+                  tile.accent && "border-accent/25 bg-accent/10",
+                )}
+                key={tile.label}
+              >
+                <KPI.Header>
+                  <KPI.Title
+                    className={cn(
+                      "text-sm",
+                      tile.accent ? "text-accent-foreground" : "text-muted",
+                    )}
+                  >
+                    {tile.label}
+                  </KPI.Title>
+                </KPI.Header>
+                <KPI.Content>
+                  <KPI.Value
+                    className={cn(
+                      "font-bold font-mono text-2xl",
+                      tile.accent ? "text-accent" : "text-foreground",
+                    )}
+                    locale="en-SG"
+                    maximumFractionDigits={1}
+                    style="percent"
+                    value={tile.value}
+                  />
+                </KPI.Content>
+              </KPI>
+            ))}
           </div>
 
-          <div>
-            <h3 className="mb-3 font-semibold text-sm">
-              OA/SA/MA Distribution
-            </h3>
+          <div className="flex flex-col gap-4">
+            <h3 className="font-semibold text-sm">OA/SA/MA Distribution</h3>
             <div className="grid grid-cols-3 gap-4">
-              <div className="flex flex-col gap-2">
-                <span className="text-muted text-xs">OA</span>
-                <span className="font-medium font-mono">
-                  {formatPercentage(ageGroup.distributionRate.OA, {
-                    decimalPlaces: 1,
-                  })}
-                </span>
-                <span className="text-muted text-xs">of contributions</span>
-              </div>
-              <div className="flex flex-col gap-2">
-                <span className="text-muted text-xs">SA</span>
-                <span className="font-medium font-mono">
-                  {formatPercentage(ageGroup.distributionRate.SA, {
-                    decimalPlaces: 1,
-                  })}
-                </span>
-                <span className="text-muted text-xs">of contributions</span>
-              </div>
-              <div className="flex flex-col gap-2">
-                <span className="text-muted text-xs">MA</span>
-                <span className="font-medium font-mono">
-                  {formatPercentage(ageGroup.distributionRate.MA, {
-                    decimalPlaces: 1,
-                  })}
-                </span>
-                <span className="text-muted text-xs">of contributions</span>
-              </div>
+              {(
+                [
+                  ["OA", ageGroup.distributionRate.OA],
+                  ["SA", ageGroup.distributionRate.SA],
+                  ["MA", ageGroup.distributionRate.MA],
+                ] as const
+              ).map(([label, rate]) => (
+                <div className="flex flex-col gap-2" key={label}>
+                  <span className="text-muted text-xs">{label}</span>
+                  <span className="font-medium font-mono">
+                    {formatPercentage(rate, { decimalPlaces: 1 })}
+                  </span>
+                  <span className="text-muted text-xs">of contributions</span>
+                </div>
+              ))}
             </div>
           </div>
 
-          <div className="flex items-center justify-between rounded-lg border p-4">
-            <div>
+          <Surface
+            className="flex flex-col items-start justify-between gap-4 rounded-lg p-4 sm:flex-row sm:items-center"
+            variant="secondary"
+          >
+            <div className="flex flex-col gap-2">
               <p className="font-medium">See Your Long-Term Projection</p>
               <p className="text-muted text-sm">
                 Project your CPF balances through retirement based on these
@@ -101,16 +122,16 @@ const CpfAgeSpecificBlock = ({ ageGroup }: CpfAgeSpecificBlockProps) => {
               </p>
             </div>
             <Link
+              className={cn(buttonVariants({ size: "md" }), "shrink-0")}
               href={`/projection?birthDate=${birthDate}`}
-              className="inline-flex h-9 items-center justify-center rounded-4xl bg-foreground px-4 font-medium text-background text-sm transition-colors hover:bg-foreground/80"
             >
               View Projection
             </Link>
-          </div>
+          </Surface>
         </Card.Content>
       </Card>
     </section>
   );
-};
+}
 
 export default CpfAgeSpecificBlock;

--- a/src/components/seo/cpf-interest-tiers-block.tsx
+++ b/src/components/seo/cpf-interest-tiers-block.tsx
@@ -65,13 +65,30 @@ function CpfInterestTiersBlock() {
                 </KPI.Title>
               </KPI.Header>
               <KPI.Content>
-                <span className="font-bold text-2xl text-foreground">
-                  +
-                  {formatPercentage(CPF_EXTRA_INTEREST_RATE, {
-                    decimalPlaces: 0,
-                  })}{" "}
-                  + {CPF_EXTRA_INTEREST_RATE * 100}%
-                </span>
+                <div className="flex items-baseline gap-2">
+                  <KPI.Value
+                    className="font-bold text-2xl text-foreground"
+                    locale="en-SG"
+                    maximumFractionDigits={0}
+                    signDisplay="always"
+                    style="percent"
+                    value={CPF_EXTRA_INTEREST_RATE}
+                  />
+                  <span
+                    aria-hidden="true"
+                    className="font-bold text-2xl text-foreground"
+                  >
+                    +
+                  </span>
+                  <KPI.Value
+                    className="font-bold text-2xl text-foreground"
+                    locale="en-SG"
+                    maximumFractionDigits={0}
+                    signDisplay="always"
+                    style="percent"
+                    value={CPF_EXTRA_INTEREST_RATE}
+                  />
+                </div>
               </KPI.Content>
               <KPI.Footer className="flex flex-col gap-2 text-muted text-sm">
                 <span>

--- a/src/components/seo/cpf-interest-tiers-block.tsx
+++ b/src/components/seo/cpf-interest-tiers-block.tsx
@@ -1,4 +1,5 @@
 import { Card } from "@heroui/react";
+import { KPI } from "@heroui-pro/react";
 import {
   CPF_ADDITIONAL_SENIOR_INTEREST_CAP,
   CPF_EXTRA_INTEREST_CAP,
@@ -6,85 +7,119 @@ import {
 } from "@/constants/cpf-interest-tiers";
 import { formatCurrency, formatNumber, formatPercentage } from "@/lib/format";
 
-const CpfInterestTiersBlock = () => (
-  <section aria-labelledby="cpf-interest-tiers" data-content-block="definition">
-    <Card>
-      <Card.Header>
-        <Card.Title id="cpf-interest-tiers">
-          CPF Extra Interest: How the 1% Bonus Works
-        </Card.Title>
-      </Card.Header>
-      <Card.Content className="flex flex-col gap-4">
-        <p>
-          CPF members earn <strong>extra interest</strong> on top of base rates
-          to boost retirement savings. This bonus interest applies to the first
-          portion of your combined CPF balances.
-        </p>
+function CpfInterestTiersBlock() {
+  return (
+    <section
+      aria-labelledby="cpf-interest-tiers"
+      data-content-block="definition"
+    >
+      <Card>
+        <Card.Header>
+          <Card.Title id="cpf-interest-tiers">
+            CPF Extra Interest: How the 1% Bonus Works
+          </Card.Title>
+        </Card.Header>
+        <Card.Content className="flex flex-col gap-4">
+          <p>
+            CPF members earn <strong>extra interest</strong> on top of base
+            rates to boost retirement savings. This bonus interest applies to
+            the first portion of your combined CPF balances.
+          </p>
 
-        <div className="grid gap-4 md:grid-cols-2">
-          <div className="rounded-lg border border-border bg-surface-tertiary/50 p-4">
-            <p className="mb-2 font-semibold text-sm">Under Age 55</p>
-            <p className="font-bold text-2xl text-foreground">
-              +{formatPercentage(CPF_EXTRA_INTEREST_RATE, { decimalPlaces: 0 })}
-            </p>
-            <p className="mt-1 text-muted text-sm">
-              On the first S${formatNumber(CPF_EXTRA_INTEREST_CAP)} of combined
-              OA + SA + MA balances
-            </p>
-            <p className="mt-2 text-muted text-xs">
-              Max extra interest:{" "}
-              {formatCurrency(
-                CPF_EXTRA_INTEREST_CAP * CPF_EXTRA_INTEREST_RATE,
-                0,
-              )}{" "}
-              per year
-            </p>
+          <div className="grid gap-4 md:grid-cols-2">
+            <KPI className="gap-2">
+              <KPI.Header>
+                <KPI.Title className="font-semibold text-sm">
+                  Under Age 55
+                </KPI.Title>
+              </KPI.Header>
+              <KPI.Content>
+                <KPI.Value
+                  className="font-bold text-2xl text-foreground"
+                  locale="en-SG"
+                  maximumFractionDigits={0}
+                  signDisplay="always"
+                  style="percent"
+                  value={CPF_EXTRA_INTEREST_RATE}
+                />
+              </KPI.Content>
+              <KPI.Footer className="flex flex-col gap-2 text-muted text-sm">
+                <span>
+                  On the first S${formatNumber(CPF_EXTRA_INTEREST_CAP)} of
+                  combined OA + SA + MA balances
+                </span>
+                <span className="text-xs">
+                  Max extra interest:{" "}
+                  {formatCurrency(
+                    CPF_EXTRA_INTEREST_CAP * CPF_EXTRA_INTEREST_RATE,
+                    0,
+                  )}{" "}
+                  per year
+                </span>
+              </KPI.Footer>
+            </KPI>
+            <KPI className="gap-2">
+              <KPI.Header>
+                <KPI.Title className="font-semibold text-sm">
+                  Age 55 and Above
+                </KPI.Title>
+              </KPI.Header>
+              <KPI.Content>
+                <span className="font-bold text-2xl text-foreground">
+                  +
+                  {formatPercentage(CPF_EXTRA_INTEREST_RATE, {
+                    decimalPlaces: 0,
+                  })}{" "}
+                  + {CPF_EXTRA_INTEREST_RATE * 100}%
+                </span>
+              </KPI.Content>
+              <KPI.Footer className="flex flex-col gap-2 text-muted text-sm">
+                <span>
+                  Base tier: +
+                  {formatPercentage(CPF_EXTRA_INTEREST_RATE, {
+                    decimalPlaces: 0,
+                  })}{" "}
+                  on first S${formatNumber(CPF_EXTRA_INTEREST_CAP)} of combined
+                  balances
+                  <br />
+                  Senior tier: Additional +
+                  {formatPercentage(CPF_EXTRA_INTEREST_RATE, {
+                    decimalPlaces: 0,
+                  })}{" "}
+                  on first S${formatNumber(CPF_ADDITIONAL_SENIOR_INTEREST_CAP)}{" "}
+                  of combined balances
+                </span>
+                <span className="text-xs">
+                  Max extra interest:{" "}
+                  {formatCurrency(
+                    CPF_EXTRA_INTEREST_CAP * CPF_EXTRA_INTEREST_RATE +
+                      CPF_ADDITIONAL_SENIOR_INTEREST_CAP *
+                        CPF_EXTRA_INTEREST_RATE,
+                    0,
+                  )}{" "}
+                  per year
+                </span>
+              </KPI.Footer>
+            </KPI>
           </div>
-          <div className="rounded-lg border border-border bg-surface-tertiary/50 p-4">
-            <p className="mb-2 font-semibold text-sm">Age 55 and Above</p>
-            <p className="font-bold text-2xl text-foreground">
-              +{formatPercentage(CPF_EXTRA_INTEREST_RATE, { decimalPlaces: 0 })}{" "}
-              + {CPF_EXTRA_INTEREST_RATE * 100}%
-            </p>
-            <p className="mt-1 text-muted text-sm">
-              Base tier: +
-              {formatPercentage(CPF_EXTRA_INTEREST_RATE, { decimalPlaces: 0 })}{" "}
-              on first S$
-              {formatNumber(CPF_EXTRA_INTEREST_CAP)} of combined balances
-              <br />
-              Senior tier: Additional +
-              {formatPercentage(CPF_EXTRA_INTEREST_RATE, { decimalPlaces: 0 })}{" "}
-              on first S${formatNumber(CPF_ADDITIONAL_SENIOR_INTEREST_CAP)} of
-              combined balances
-            </p>
-            <p className="mt-2 text-muted text-xs">
-              Max extra interest:{" "}
-              {formatCurrency(
-                CPF_EXTRA_INTEREST_CAP * CPF_EXTRA_INTEREST_RATE +
-                  CPF_ADDITIONAL_SENIOR_INTEREST_CAP * CPF_EXTRA_INTEREST_RATE,
-                0,
-              )}{" "}
-              per year
-            </p>
-          </div>
-        </div>
 
-        <p className="text-muted text-sm">
-          <strong>How it works:</strong> The extra interest is paid into your
-          Special Account (or Retirement Account if you{"'"}re 55+). This means
-          your SA/RA grows faster, directly increasing your CPF LIFE payouts in
-          retirement.
-        </p>
+          <p className="text-muted text-sm">
+            <strong>How it works:</strong> The extra interest is paid into your
+            Special Account (or Retirement Account if you{"'"}re 55+). This
+            means your SA/RA grows faster, directly increasing your CPF LIFE
+            payouts in retirement.
+          </p>
 
-        <p className="text-muted text-sm">
-          <strong>Example:</strong> A 30-year-old with S$50,000 across OA + SA +
-          MA earns an extra {formatCurrency(50000 * 0.01, 0)} per year (
-          {formatCurrency((50000 * 0.01) / 12, 0)} per month) on top of base
-          rates.
-        </p>
-      </Card.Content>
-    </Card>
-  </section>
-);
+          <p className="text-muted text-sm">
+            <strong>Example:</strong> A 30-year-old with S$50,000 across OA + SA
+            + MA earns an extra {formatCurrency(50000 * 0.01, 0)} per year (
+            {formatCurrency((50000 * 0.01) / 12, 0)} per month) on top of base
+            rates.
+          </p>
+        </Card.Content>
+      </Card>
+    </section>
+  );
+}
 
 export default CpfInterestTiersBlock;

--- a/src/components/seo/cpf-retirement-sums-block.tsx
+++ b/src/components/seo/cpf-retirement-sums-block.tsx
@@ -1,11 +1,12 @@
 import { Card } from "@heroui/react";
+import { KPI } from "@heroui-pro/react";
 import {
   CPF_RETIREMENT_SUMS,
   getRetirementSumsForYear,
 } from "@/constants/cpf-retirement-sums";
 import { formatNumber } from "@/lib/format";
 
-const CpfRetirementSumsBlock = () => {
+function CpfRetirementSumsBlock() {
   const currentYear = new Date().getFullYear();
   const sums = getRetirementSumsForYear(currentYear);
 
@@ -18,6 +19,24 @@ const CpfRetirementSumsBlock = () => {
     .map(Number)
     .filter((y) => y > currentYear)
     .slice(0, 3);
+
+  const tiles = [
+    {
+      label: "Basic Retirement Sum",
+      value: sums.brs,
+      note: "Minimum for CPF LIFE. Provides basic monthly payouts for life.",
+    },
+    {
+      label: "Full Retirement Sum",
+      value: sums.frs,
+      note: `${frsMultiple}× BRS. Higher monthly payouts for a more comfortable retirement.`,
+    },
+    {
+      label: "Enhanced Retirement Sum",
+      value: sums.ers,
+      note: `${ersMultiple}× BRS. Maximum monthly payouts for enhanced retirement income.`,
+    },
+  ];
 
   return (
     <section aria-labelledby="cpf-retirement-sums" data-content-block="dataset">
@@ -36,37 +55,28 @@ const CpfRetirementSumsBlock = () => {
           </p>
 
           <div className="grid gap-4 md:grid-cols-3">
-            <div className="rounded-lg border border-border bg-surface-tertiary/50 p-4">
-              <p className="mb-1 font-semibold text-sm">Basic Retirement Sum</p>
-              <p className="font-bold text-2xl text-foreground">
-                S${formatNumber(sums.brs)}
-              </p>
-              <p className="mt-1 text-muted text-xs">
-                Minimum for CPF LIFE. Provides basic monthly payouts for life.
-              </p>
-            </div>
-            <div className="rounded-lg border border-border bg-surface-tertiary/50 p-4">
-              <p className="mb-1 font-semibold text-sm">Full Retirement Sum</p>
-              <p className="font-bold text-2xl text-foreground">
-                S${formatNumber(sums.frs)}
-              </p>
-              <p className="mt-1 text-muted text-xs">
-                {frsMultiple}× BRS. Higher monthly payouts for a more
-                comfortable retirement.
-              </p>
-            </div>
-            <div className="rounded-lg border border-border bg-surface-tertiary/50 p-4">
-              <p className="mb-1 font-semibold text-sm">
-                Enhanced Retirement Sum
-              </p>
-              <p className="font-bold text-2xl text-foreground">
-                S${formatNumber(sums.ers)}
-              </p>
-              <p className="mt-1 text-muted text-xs">
-                {ersMultiple}× BRS. Maximum monthly payouts for enhanced
-                retirement income.
-              </p>
-            </div>
+            {tiles.map((tile) => (
+              <KPI className="gap-2" key={tile.label}>
+                <KPI.Header>
+                  <KPI.Title className="font-semibold text-sm">
+                    {tile.label}
+                  </KPI.Title>
+                </KPI.Header>
+                <KPI.Content>
+                  <KPI.Value
+                    className="font-bold text-2xl text-foreground"
+                    currency="SGD"
+                    locale="en-SG"
+                    maximumFractionDigits={0}
+                    style="currency"
+                    value={tile.value}
+                  />
+                </KPI.Content>
+                <KPI.Footer className="text-muted text-xs">
+                  {tile.note}
+                </KPI.Footer>
+              </KPI>
+            ))}
           </div>
 
           {futureYears.length > 0 && (
@@ -96,6 +106,6 @@ const CpfRetirementSumsBlock = () => {
       </Card>
     </section>
   );
-};
+}
 
 export default CpfRetirementSumsBlock;

--- a/src/components/what-if/what-if-content.tsx
+++ b/src/components/what-if/what-if-content.tsx
@@ -11,6 +11,7 @@ import {
   ToggleButton,
   ToggleButtonGroup,
 } from "@heroui/react";
+import { EmptyState } from "@heroui-pro/react";
 import {
   parseAsInteger,
   parseAsStringLiteral,
@@ -246,20 +247,20 @@ function ColumnCard({ title, tag, rows, isScenario }: ColumnCardProps) {
   );
 }
 
-function EmptyState() {
+function ComparisonEmptyState() {
   return (
-    <Card>
-      <Card.Header>
-        <Card.Title>Enter your salary and date of birth</Card.Title>
-        <Card.Description>
+    <EmptyState>
+      <EmptyState.Header>
+        <EmptyState.Title>Enter your salary and date of birth</EmptyState.Title>
+        <EmptyState.Description>
           The comparison runs on your own numbers. Add them on the home page and
           this screen fills in.
-        </Card.Description>
-      </Card.Header>
-      <Card.Content>
+        </EmptyState.Description>
+      </EmptyState.Header>
+      <EmptyState.Content>
         <Link href="/">Go to the home page</Link>
-      </Card.Content>
-    </Card>
+      </EmptyState.Content>
+    </EmptyState>
   );
 }
 
@@ -472,7 +473,7 @@ export default function WhatIfContent() {
       {!mounted ? (
         <ComparisonSkeleton />
       ) : result === null ? (
-        <EmptyState />
+        <ComparisonEmptyState />
       ) : (
         <div className="grid gap-8 md:grid-cols-2">
           <ColumnCard


### PR DESCRIPTION
- Restore layout, projection, investments, readiness, CPF LIFE, rates, what-if, and SEO tiles onto HeroUI OSS/Pro primitives
- Use Link, Sheet, KPI, charts, RadioButtonGroup, EmptyState, and Alert instead of Tailwind-only rebuilds
- Keep PDF brand colours on shared tokens; update header tests for Sheet markup

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>