### PR TITLE
Use RSC-safe KPI.Value in SEO statistic blocks

### DIFF
--- a/src/components/seo/cpf-statistic-block.tsx
+++ b/src/components/seo/cpf-statistic-block.tsx
@@ -5,23 +5,28 @@ import { CPF_INTEREST_FLOOR_RATES } from "@/constants/cpf-interest-rates";
 
 function CpfStatisticBlock() {
   const currentCeiling = CPF_INCOME_CEILING["2026-01-01"];
-  const stats = [
+  const stats: Array<{
+    label: string;
+    value: number;
+    style: "currency" | "percent";
+    detail: string;
+  }> = [
     {
       label: "Current income ceiling (2026)",
       value: currentCeiling,
-      style: "currency" as const,
+      style: "currency",
       detail: "Final ceiling under 2023 Budget changes",
     },
     {
       label: "OA interest rate (floor)",
       value: CPF_INTEREST_FLOOR_RATES.OA / 100,
-      style: "percent" as const,
+      style: "percent",
       detail: "Fixed, not pegged to SGS · p.a.",
     },
     {
       label: "SMRA interest rate (floor)",
       value: CPF_INTEREST_FLOOR_RATES.SMRA / 100,
-      style: "percent" as const,
+      style: "percent",
       detail: "Minimum guaranteed; may earn more · p.a.",
     },
   ];

--- a/src/components/seo/cpf-statistic-block.tsx
+++ b/src/components/seo/cpf-statistic-block.tsx
@@ -1,25 +1,28 @@
 import { Card } from "@heroui/react";
+import { KPI } from "@heroui-pro/react";
 import { CPF_INCOME_CEILING } from "@/constants";
 import { CPF_INTEREST_FLOOR_RATES } from "@/constants/cpf-interest-rates";
-import { formatNumber } from "@/lib/format";
 
-const CpfStatisticBlock = () => {
+function CpfStatisticBlock() {
   const currentCeiling = CPF_INCOME_CEILING["2026-01-01"];
   const stats = [
     {
       label: "Current income ceiling (2026)",
-      value: `S$${formatNumber(currentCeiling)}`,
+      value: currentCeiling,
+      style: "currency" as const,
       detail: "Final ceiling under 2023 Budget changes",
     },
     {
       label: "OA interest rate (floor)",
-      value: `${CPF_INTEREST_FLOOR_RATES.OA}% p.a.`,
-      detail: "Fixed, not pegged to SGS",
+      value: CPF_INTEREST_FLOOR_RATES.OA / 100,
+      style: "percent" as const,
+      detail: "Fixed, not pegged to SGS · p.a.",
     },
     {
       label: "SMRA interest rate (floor)",
-      value: `${CPF_INTEREST_FLOOR_RATES.SMRA}% p.a.`,
-      detail: "Minimum guaranteed; may earn more",
+      value: CPF_INTEREST_FLOOR_RATES.SMRA / 100,
+      style: "percent" as const,
+      detail: "Minimum guaranteed; may earn more · p.a.",
     },
   ];
 
@@ -34,22 +37,32 @@ const CpfStatisticBlock = () => {
         <Card.Content>
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {stats.map((stat) => (
-              <div
-                key={stat.label}
-                className="rounded-lg border border-border bg-surface-tertiary/30 p-4"
-              >
-                <p className="mb-2 text-muted text-sm">{stat.label}</p>
-                <p className="font-bold font-mono text-2xl text-foreground">
-                  {stat.value}
-                </p>
-                <p className="text-muted text-xs">{stat.detail}</p>
-              </div>
+              <KPI className="gap-2" key={stat.label}>
+                <KPI.Header>
+                  <KPI.Title className="text-muted text-sm">
+                    {stat.label}
+                  </KPI.Title>
+                </KPI.Header>
+                <KPI.Content>
+                  <KPI.Value
+                    className="font-bold font-mono text-2xl text-foreground"
+                    currency={stat.style === "currency" ? "SGD" : undefined}
+                    locale="en-SG"
+                    maximumFractionDigits={stat.style === "percent" ? 1 : 0}
+                    style={stat.style}
+                    value={stat.value}
+                  />
+                </KPI.Content>
+                <KPI.Footer className="text-muted text-xs">
+                  {stat.detail}
+                </KPI.Footer>
+              </KPI>
             ))}
           </div>
         </Card.Content>
       </Card>
     </section>
   );
-};
+}
 
 export default CpfStatisticBlock;

--- a/src/components/seo/cpf-top-up-limits-block.tsx
+++ b/src/components/seo/cpf-top-up-limits-block.tsx
@@ -1,4 +1,5 @@
 import { Card } from "@heroui/react";
+import { KPI } from "@heroui-pro/react";
 import { formatNumber } from "@/lib/format";
 
 /**
@@ -19,7 +20,7 @@ const FAMILY_INCOME_CONDITION = 8000;
 const MRSS_ANNUAL_CAP = 2000;
 const MRSS_LIFETIME_CAP = 20000;
 
-const CpfTopUpLimitsBlock = () => {
+function CpfTopUpLimitsBlock() {
   const combinedRelief = TAX_RELIEF_SELF + TAX_RELIEF_FAMILY;
   // Illustrative only: the 4% SMRA floor rate compounded from age 30 to 55,
   // rounded to the nearest hundred. Extra interest is not modelled.
@@ -45,38 +46,62 @@ const CpfTopUpLimitsBlock = () => {
           </p>
 
           <div className="grid gap-4 md:grid-cols-2">
-            <div className="rounded-lg border border-border bg-surface-tertiary/50 p-4">
-              <p className="mb-1 font-semibold text-sm">
-                Top-Up to Your Own Account
-              </p>
-              <p className="font-bold text-2xl text-foreground">
-                Up to S${formatNumber(TAX_RELIEF_SELF)}
-              </p>
-              <p className="mt-1 text-muted text-xs">
-                Cash top-up to your SA (under 55) or RA (55+) qualifies for tax
-                relief
-              </p>
-              <p className="mt-2 text-accent text-xs">
-                Tax relief cap: S${formatNumber(TAX_RELIEF_SELF)} per calendar
-                year
-              </p>
-            </div>
-            <div className="rounded-lg border border-border bg-surface-tertiary/50 p-4">
-              <p className="mb-1 font-semibold text-sm">
-                Top-Up for Family Members
-              </p>
-              <p className="font-bold text-2xl text-foreground">
-                Up to S${formatNumber(TAX_RELIEF_FAMILY)}
-              </p>
-              <p className="mt-1 text-muted text-xs">
-                Top-up parents, parents-in-law, grandparents, spouse, or
-                siblings
-              </p>
-              <p className="mt-2 text-accent text-xs">
-                Separate S${formatNumber(TAX_RELIEF_FAMILY)} cap for family
-                top-ups
-              </p>
-            </div>
+            <KPI className="gap-2">
+              <KPI.Header>
+                <KPI.Title className="font-semibold text-sm">
+                  Top-Up to Your Own Account
+                </KPI.Title>
+              </KPI.Header>
+              <KPI.Content>
+                <KPI.Value
+                  className="font-bold text-2xl text-foreground"
+                  currency="SGD"
+                  locale="en-SG"
+                  maximumFractionDigits={0}
+                  style="currency"
+                  value={TAX_RELIEF_SELF}
+                />
+              </KPI.Content>
+              <KPI.Footer className="flex flex-col gap-2 text-muted text-xs">
+                <span>Up to this amount of cash top-up qualifies for relief</span>
+                <span>
+                  Cash top-up to your SA (under 55) or RA (55+) qualifies for
+                  tax relief
+                </span>
+                <span className="text-accent">
+                  Tax relief cap: S${formatNumber(TAX_RELIEF_SELF)} per calendar
+                  year
+                </span>
+              </KPI.Footer>
+            </KPI>
+            <KPI className="gap-2">
+              <KPI.Header>
+                <KPI.Title className="font-semibold text-sm">
+                  Top-Up for Family Members
+                </KPI.Title>
+              </KPI.Header>
+              <KPI.Content>
+                <KPI.Value
+                  className="font-bold text-2xl text-foreground"
+                  currency="SGD"
+                  locale="en-SG"
+                  maximumFractionDigits={0}
+                  style="currency"
+                  value={TAX_RELIEF_FAMILY}
+                />
+              </KPI.Content>
+              <KPI.Footer className="flex flex-col gap-2 text-muted text-xs">
+                <span>Up to this amount of family top-up qualifies for relief</span>
+                <span>
+                  Top-up parents, parents-in-law, grandparents, spouse, or
+                  siblings
+                </span>
+                <span className="text-accent">
+                  Separate S${formatNumber(TAX_RELIEF_FAMILY)} cap for family
+                  top-ups
+                </span>
+              </KPI.Footer>
+            </KPI>
           </div>
 
           <p>
@@ -145,6 +170,6 @@ const CpfTopUpLimitsBlock = () => {
       </Card>
     </section>
   );
-};
+}
 
 export default CpfTopUpLimitsBlock;

--- a/src/components/seo/cpf-top-up-limits-block.tsx
+++ b/src/components/seo/cpf-top-up-limits-block.tsx
@@ -63,7 +63,6 @@ function CpfTopUpLimitsBlock() {
                 />
               </KPI.Content>
               <KPI.Footer className="flex flex-col gap-2 text-muted text-xs">
-                <span>Up to this amount of cash top-up qualifies for relief</span>
                 <span>
                   Cash top-up to your SA (under 55) or RA (55+) qualifies for
                   tax relief
@@ -91,7 +90,6 @@ function CpfTopUpLimitsBlock() {
                 />
               </KPI.Content>
               <KPI.Footer className="flex flex-col gap-2 text-muted text-xs">
-                <span>Up to this amount of family top-up qualifies for relief</span>
                 <span>
                   Top-up parents, parents-in-law, grandparents, spouse, or
                   siblings


### PR DESCRIPTION
- Restore SEO statistic and top-up KPI blocks with HeroUI KPI
- Use self-closing `KPI.Value` so Server Components do not pass render-prop functions into Client Components

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>