### PR TITLE
Migrate product headings and ledes to HeroUI Typography

### DIFF
--- a/src/app/(main)/accrued-interest/page.tsx
+++ b/src/app/(main)/accrued-interest/page.tsx
@@ -4,6 +4,7 @@ import { Suspense } from "react";
 import type { Graph } from "schema-dts";
 import { AccruedInterestContent } from "@/components/accrued-interest/accrued-interest-content";
 import { StructuredData } from "@/components/seo/structured-data";
+import { Eyebrow } from "@/components/shared/section-header";
 import { BASE_URL, OG_BASE, WEBSITE_ID } from "@/config";
 
 const PAGE_URL = `${BASE_URL}/accrued-interest`;
@@ -73,9 +74,7 @@ export default function AccruedInterestPage() {
     <>
       <StructuredData data={schema} />
       <header className="flex flex-col gap-2">
-        <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">
-          Home &amp; OA
-        </span>
+        <Eyebrow color="muted">Home &amp; OA</Eyebrow>
         <Typography type="h1">
           Accrued interest, without the forum arguments
         </Typography>

--- a/src/app/(main)/accrued-interest/page.tsx
+++ b/src/app/(main)/accrued-interest/page.tsx
@@ -76,19 +76,18 @@ export default function AccruedInterestPage() {
         <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">
           Home &amp; OA
         </span>
-        <Typography type="h1" className="text-balance">
+        <Typography type="h1">
           Accrued interest, without the forum arguments
         </Typography>
-        <Typography
-          color="muted"
-          className="max-w-[76ch] text-pretty leading-relaxed"
-        >
-          OA money you put into a home keeps a running 2.5% tab: the interest it
-          would have earned had it stayed. When you sell, the principal plus
-          that accrued interest returns to your CPF before you see any cash. It
-          is a refund to yourself, not a penalty, but it changes what a sale
-          actually pays out.
-        </Typography>
+        <div className="max-w-[76ch]">
+          <Typography color="muted">
+            OA money you put into a home keeps a running 2.5% tab: the interest
+            it would have earned had it stayed. When you sell, the principal
+            plus that accrued interest returns to your CPF before you see any
+            cash. It is a refund to yourself, not a penalty, but it changes what
+            a sale actually pays out.
+          </Typography>
+        </div>
       </header>
       <Suspense>
         <AccruedInterestContent />

--- a/src/app/(main)/accrued-interest/page.tsx
+++ b/src/app/(main)/accrued-interest/page.tsx
@@ -1,3 +1,4 @@
+import { Typography } from "@heroui/react";
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import type { Graph } from "schema-dts";
@@ -75,16 +76,19 @@ export default function AccruedInterestPage() {
         <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">
           Home &amp; OA
         </span>
-        <h1 className="text-balance font-semibold text-4xl tracking-tight">
+        <Typography type="h1" className="text-balance">
           Accrued interest, without the forum arguments
-        </h1>
-        <p className="max-w-[76ch] text-pretty text-base text-muted leading-relaxed">
+        </Typography>
+        <Typography
+          color="muted"
+          className="max-w-[76ch] text-pretty leading-relaxed"
+        >
           OA money you put into a home keeps a running 2.5% tab: the interest it
           would have earned had it stayed. When you sell, the principal plus
           that accrued interest returns to your CPF before you see any cash. It
           is a refund to yourself, not a penalty, but it changes what a sale
           actually pays out.
-        </p>
+        </Typography>
       </header>
       <Suspense>
         <AccruedInterestContent />

--- a/src/app/(main)/calculator/page.tsx
+++ b/src/app/(main)/calculator/page.tsx
@@ -1,3 +1,4 @@
+import { Typography } from "@heroui/react";
 import type { Metadata } from "next";
 import { createSearchParamsCache, parseAsInteger } from "nuqs/server";
 import type { Graph } from "schema-dts";
@@ -199,9 +200,9 @@ async function CalculatorPage({
             This month
           </span>
           <div className="flex flex-wrap items-end justify-between gap-4">
-            <h1 className="text-balance font-semibold text-4xl tracking-tight">
+            <Typography type="h1" className="text-balance">
               Where this month&apos;s money went
-            </h1>
+            </Typography>
             <CalculatorActions />
           </div>
         </header>

--- a/src/app/(main)/calculator/page.tsx
+++ b/src/app/(main)/calculator/page.tsx
@@ -7,6 +7,7 @@ import CalculatorContent from "@/components/calculator/calculator-content";
 import CpfAgeSpecificBlock from "@/components/seo/cpf-age-specific-block";
 import IncomeCeilingDefinitionBlock from "@/components/seo/income-ceiling-definition-block";
 import { StructuredData } from "@/components/seo/structured-data";
+import { Eyebrow } from "@/components/shared/section-header";
 import { BASE_URL, WEBSITE_ID } from "@/config";
 import faqCalculatorData from "@/data/faq-calculator.json";
 import { findAgeGroup } from "@/lib/find-age-group";
@@ -196,9 +197,7 @@ async function CalculatorPage({
       <StructuredData data={schema} />
       <div className="flex flex-col gap-8">
         <header className="flex flex-col gap-2">
-          <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">
-            This month
-          </span>
+          <Eyebrow color="muted">This month</Eyebrow>
           <div className="flex flex-wrap items-end justify-between gap-4">
             <Typography type="h1">
               Where this month&apos;s money went

--- a/src/app/(main)/calculator/page.tsx
+++ b/src/app/(main)/calculator/page.tsx
@@ -200,7 +200,7 @@ async function CalculatorPage({
             This month
           </span>
           <div className="flex flex-wrap items-end justify-between gap-4">
-            <Typography type="h1" className="text-balance">
+            <Typography type="h1">
               Where this month&apos;s money went
             </Typography>
             <CalculatorActions />

--- a/src/app/(main)/cpf-cheat-sheet/page.tsx
+++ b/src/app/(main)/cpf-cheat-sheet/page.tsx
@@ -4,6 +4,7 @@ import type { Graph } from "schema-dts";
 import { CheatSheetCard } from "@/components/cpf-cheat-sheet/cheat-sheet-card";
 import { PrintButton } from "@/components/cpf-cheat-sheet/print-button";
 import { StructuredData } from "@/components/seo/structured-data";
+import { Eyebrow } from "@/components/shared/section-header";
 import { BASE_URL, OG_BASE, WEBSITE_ID } from "@/config";
 
 const PAGE_URL = `${BASE_URL}/cpf-cheat-sheet`;
@@ -81,9 +82,7 @@ export default function CpfCheatSheetPage() {
         {PRINT_STYLES}
       </style>
       <header className="flex flex-col gap-2">
-        <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">
-          Cheat sheet
-        </span>
+        <Eyebrow color="muted">Cheat sheet</Eyebrow>
         <div className="flex flex-wrap items-end justify-between gap-4">
           <Typography type="h1">One page, on the fridge, done</Typography>
           <div className="flex flex-wrap gap-2">

--- a/src/app/(main)/cpf-cheat-sheet/page.tsx
+++ b/src/app/(main)/cpf-cheat-sheet/page.tsx
@@ -1,4 +1,4 @@
-import { buttonVariants } from "@heroui/react";
+import { buttonVariants, Typography } from "@heroui/react";
 import type { Metadata } from "next";
 import type { Graph } from "schema-dts";
 import { CheatSheetCard } from "@/components/cpf-cheat-sheet/cheat-sheet-card";
@@ -85,9 +85,9 @@ export default function CpfCheatSheetPage() {
           Cheat sheet
         </span>
         <div className="flex flex-wrap items-end justify-between gap-4">
-          <h1 className="text-balance font-semibold text-4xl tracking-tight">
+          <Typography type="h1" className="text-balance">
             One page, on the fridge, done
-          </h1>
+          </Typography>
           <div className="flex flex-wrap gap-2">
             <PrintButton />
             <a
@@ -98,11 +98,14 @@ export default function CpfCheatSheetPage() {
             </a>
           </div>
         </div>
-        <p className="max-w-[76ch] text-pretty text-base text-muted leading-relaxed">
+        <Typography
+          color="muted"
+          className="max-w-[76ch] text-pretty leading-relaxed"
+        >
           Every reference number for 2026 on a single printable sheet. No
           inputs, no personalisation, just the figures you keep having to look
           up.
-        </p>
+        </Typography>
       </header>
       <CheatSheetCard />
     </>

--- a/src/app/(main)/cpf-cheat-sheet/page.tsx
+++ b/src/app/(main)/cpf-cheat-sheet/page.tsx
@@ -85,9 +85,7 @@ export default function CpfCheatSheetPage() {
           Cheat sheet
         </span>
         <div className="flex flex-wrap items-end justify-between gap-4">
-          <Typography type="h1" className="text-balance">
-            One page, on the fridge, done
-          </Typography>
+          <Typography type="h1">One page, on the fridge, done</Typography>
           <div className="flex flex-wrap gap-2">
             <PrintButton />
             <a
@@ -98,14 +96,13 @@ export default function CpfCheatSheetPage() {
             </a>
           </div>
         </div>
-        <Typography
-          color="muted"
-          className="max-w-[76ch] text-pretty leading-relaxed"
-        >
-          Every reference number for 2026 on a single printable sheet. No
-          inputs, no personalisation, just the figures you keep having to look
-          up.
-        </Typography>
+        <div className="max-w-[76ch]">
+          <Typography color="muted">
+            Every reference number for 2026 on a single printable sheet. No
+            inputs, no personalisation, just the figures you keep having to look
+            up.
+          </Typography>
+        </div>
       </header>
       <CheatSheetCard />
     </>

--- a/src/app/(main)/cpf-life/page.tsx
+++ b/src/app/(main)/cpf-life/page.tsx
@@ -87,18 +87,15 @@ export default function CpfLifePage() {
           <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">
             CPF LIFE
           </span>
-          <Typography type="h1" className="text-balance">
-            One balance, three payout shapes
-          </Typography>
-          <Typography
-            color="muted"
-            className="max-w-[76ch] text-pretty leading-relaxed"
-          >
-            The plans differ in shape, not in generosity: the same Retirement
-            Account buys a flat payout, a rising one that starts lower, or a
-            lower one that can fall further. We show all three side by side and
-            rank none of them.
-          </Typography>
+          <Typography type="h1">One balance, three payout shapes</Typography>
+          <div className="max-w-[76ch]">
+            <Typography color="muted">
+              The plans differ in shape, not in generosity: the same Retirement
+              Account buys a flat payout, a rising one that starts lower, or a
+              lower one that can fall further. We show all three side by side
+              and rank none of them.
+            </Typography>
+          </div>
         </header>
         <CpfLifeContent />
         <CpfLifeDefinitionBlock />

--- a/src/app/(main)/cpf-life/page.tsx
+++ b/src/app/(main)/cpf-life/page.tsx
@@ -5,6 +5,7 @@ import CpfLifeContent from "@/components/cpf-life/cpf-life-content";
 import CpfLifeDefinitionBlock from "@/components/seo/cpf-life-definition-block";
 import CpfRetirementSumsBlock from "@/components/seo/cpf-retirement-sums-block";
 import { StructuredData } from "@/components/seo/structured-data";
+import { Eyebrow } from "@/components/shared/section-header";
 import { BASE_URL, OG_BASE, OG_IMAGE, WEBSITE_ID } from "@/config";
 import faqCpfLifeData from "@/data/faq-cpf-life.json";
 
@@ -84,9 +85,7 @@ export default function CpfLifePage() {
       <StructuredData data={schema} />
       <div className="flex flex-col gap-8">
         <header className="flex flex-col gap-2">
-          <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">
-            CPF LIFE
-          </span>
+          <Eyebrow color="muted">CPF LIFE</Eyebrow>
           <Typography type="h1">One balance, three payout shapes</Typography>
           <div className="max-w-[76ch]">
             <Typography color="muted">

--- a/src/app/(main)/cpf-life/page.tsx
+++ b/src/app/(main)/cpf-life/page.tsx
@@ -1,3 +1,4 @@
+import { Typography } from "@heroui/react";
 import type { Metadata } from "next";
 import type { Graph } from "schema-dts";
 import CpfLifeContent from "@/components/cpf-life/cpf-life-content";
@@ -86,15 +87,18 @@ export default function CpfLifePage() {
           <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">
             CPF LIFE
           </span>
-          <h1 className="text-balance font-semibold text-4xl tracking-tight">
+          <Typography type="h1" className="text-balance">
             One balance, three payout shapes
-          </h1>
-          <p className="max-w-[76ch] text-pretty text-base text-muted leading-relaxed">
+          </Typography>
+          <Typography
+            color="muted"
+            className="max-w-[76ch] text-pretty leading-relaxed"
+          >
             The plans differ in shape, not in generosity: the same Retirement
             Account buys a flat payout, a rising one that starts lower, or a
             lower one that can fall further. We show all three side by side and
             rank none of them.
-          </p>
+          </Typography>
         </header>
         <CpfLifeContent />
         <CpfLifeDefinitionBlock />

--- a/src/app/(main)/interest-rates/page.tsx
+++ b/src/app/(main)/interest-rates/page.tsx
@@ -102,17 +102,14 @@ export default function InterestRatesPage() {
         <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">
           Rates
         </span>
-        <Typography type="h1" className="text-balance">
-          Every rate that decides your numbers
-        </Typography>
-        <Typography
-          color="muted"
-          className="max-w-[76ch] text-pretty leading-relaxed"
-        >
-          Two floor rates, one peg, one bonus tier, and a contribution table
-          that changes with your age. This page is the source of every figure
-          elsewhere in SimplyCPF.
-        </Typography>
+        <Typography type="h1">Every rate that decides your numbers</Typography>
+        <div className="max-w-[76ch]">
+          <Typography color="muted">
+            Two floor rates, one peg, one bonus tier, and a contribution table
+            that changes with your age. This page is the source of every figure
+            elsewhere in SimplyCPF.
+          </Typography>
+        </div>
       </header>
       <RateTiles />
       <div className="grid gap-8 lg:grid-cols-[1.25fr_0.75fr]">

--- a/src/app/(main)/interest-rates/page.tsx
+++ b/src/app/(main)/interest-rates/page.tsx
@@ -1,3 +1,4 @@
+import { Typography } from "@heroui/react";
 import type { Metadata } from "next";
 import type { Graph } from "schema-dts";
 import { AllocationByAge } from "@/components/interest-rates/allocation-by-age";
@@ -101,14 +102,17 @@ export default function InterestRatesPage() {
         <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">
           Rates
         </span>
-        <h1 className="text-balance font-semibold text-4xl tracking-tight">
+        <Typography type="h1" className="text-balance">
           Every rate that decides your numbers
-        </h1>
-        <p className="max-w-[76ch] text-pretty text-base text-muted leading-relaxed">
+        </Typography>
+        <Typography
+          color="muted"
+          className="max-w-[76ch] text-pretty leading-relaxed"
+        >
           Two floor rates, one peg, one bonus tier, and a contribution table
           that changes with your age. This page is the source of every figure
           elsewhere in SimplyCPF.
-        </p>
+        </Typography>
       </header>
       <RateTiles />
       <div className="grid gap-8 lg:grid-cols-[1.25fr_0.75fr]">

--- a/src/app/(main)/interest-rates/page.tsx
+++ b/src/app/(main)/interest-rates/page.tsx
@@ -9,6 +9,7 @@ import CpfContributionComparisonBlock from "@/components/seo/cpf-contribution-co
 import CpfDistributionComparisonBlock from "@/components/seo/cpf-distribution-comparison-block";
 import CpfInterestTiersBlock from "@/components/seo/cpf-interest-tiers-block";
 import { StructuredData } from "@/components/seo/structured-data";
+import { Eyebrow } from "@/components/shared/section-header";
 import { BASE_URL, OG_BASE, OG_IMAGE, WEBSITE_ID } from "@/config";
 
 export const metadata: Metadata = {
@@ -99,9 +100,7 @@ export default function InterestRatesPage() {
     <>
       <StructuredData data={schema} />
       <header className="flex flex-col gap-2">
-        <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">
-          Rates
-        </span>
+        <Eyebrow color="muted">Rates</Eyebrow>
         <Typography type="h1">Every rate that decides your numbers</Typography>
         <div className="max-w-[76ch]">
           <Typography color="muted">

--- a/src/app/(main)/investments/page.tsx
+++ b/src/app/(main)/investments/page.tsx
@@ -65,11 +65,11 @@ const InvestmentsPage = () => {
     <>
       <StructuredData data={schema} />
       <div className="flex flex-col gap-8">
-        <div className="text-center">
-          <Typography type="h1" weight="bold" className="mb-4 text-balance">
+        <div className="mx-auto flex max-w-2xl flex-col gap-4 text-center">
+          <Typography type="h1">
             Is Keeping Money in CPF Your Best Move?
           </Typography>
-          <Typography color="muted" className="mx-auto max-w-2xl">
+          <Typography color="muted">
             CPF accounts offer guaranteed returns backed by the Singapore
             Government, but they are not your only option. Compare CPF growth
             against Singapore Government bonds, the STI ETF, or global equity
@@ -79,8 +79,8 @@ const InvestmentsPage = () => {
           </Typography>
         </div>
         <CPFInvestmentComparison />
-        <div className="text-center">
-          <Typography weight="medium" className="mb-4 text-lg">
+        <div className="flex flex-col items-center gap-4 text-center">
+          <Typography weight="medium">
             Haven&apos;t calculated your CPF contributions yet?
           </Typography>
           <Link

--- a/src/app/(main)/investments/page.tsx
+++ b/src/app/(main)/investments/page.tsx
@@ -1,4 +1,4 @@
-import { buttonVariants, cn } from "@heroui/react";
+import { buttonVariants, cn, Typography } from "@heroui/react";
 import { ArrowRight02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { Metadata } from "next";
@@ -66,23 +66,23 @@ const InvestmentsPage = () => {
       <StructuredData data={schema} />
       <div className="flex flex-col gap-8">
         <div className="text-center">
-          <h1 className="mb-4 font-bold text-3xl text-foreground tracking-tight md:text-4xl">
+          <Typography type="h1" weight="bold" className="mb-4 text-balance">
             Is Keeping Money in CPF Your Best Move?
-          </h1>
-          <p className="mx-auto max-w-2xl text-muted">
+          </Typography>
+          <Typography color="muted" className="mx-auto max-w-2xl">
             CPF accounts offer guaranteed returns backed by the Singapore
             Government, but they are not your only option. Compare CPF growth
             against Singapore Government bonds, the STI ETF, or global equity
             ETFs. Adjust the initial amount and investment period to see how
             each strategy performs side by side, so you can decide what best
             fits your retirement timeline.
-          </p>
+          </Typography>
         </div>
         <CPFInvestmentComparison />
         <div className="text-center">
-          <p className="mb-4 font-medium text-foreground text-lg">
+          <Typography weight="medium" className="mb-4 text-lg">
             Haven&apos;t calculated your CPF contributions yet?
-          </p>
+          </Typography>
           <Link
             href="/calculator"
             className={cn(buttonVariants({ size: "lg" }), "gap-2")}

--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -1,4 +1,4 @@
-import { Card } from "@heroui/react";
+import { Card, Typography } from "@heroui/react";
 import type { Metadata } from "next";
 import type { Graph } from "schema-dts";
 import { StructuredData } from "@/components/seo/structured-data";
@@ -53,14 +53,18 @@ export default function PrivacyPage() {
       <StructuredData data={schema} />
       <div className="flex flex-col gap-8">
         <div className="text-center">
-          <h1 className="mb-4 font-bold text-3xl text-foreground tracking-tight md:text-4xl">
+          <Typography type="h1" weight="bold" className="mb-4 text-balance">
             Privacy
-          </h1>
-          <p data-privacy-summary className="mx-auto max-w-3xl text-muted">
+          </Typography>
+          <Typography
+            color="muted"
+            data-privacy-summary
+            className="mx-auto max-w-3xl"
+          >
             SimplyCPF works without sign-up. There is no account to create, no
             email address to hand over, and no backend database holding your
             calculator inputs.
-          </p>
+          </Typography>
         </div>
 
         <Card>

--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -52,15 +52,9 @@ export default function PrivacyPage() {
     <>
       <StructuredData data={schema} />
       <div className="flex flex-col gap-8">
-        <div className="text-center">
-          <Typography type="h1" weight="bold" className="mb-4 text-balance">
-            Privacy
-          </Typography>
-          <Typography
-            color="muted"
-            data-privacy-summary
-            className="mx-auto max-w-3xl"
-          >
+        <div className="mx-auto flex max-w-3xl flex-col gap-4 text-center">
+          <Typography type="h1">Privacy</Typography>
+          <Typography color="muted" data-privacy-summary>
             SimplyCPF works without sign-up. There is no account to create, no
             email address to hand over, and no backend database holding your
             calculator inputs.

--- a/src/app/(main)/projection/page.tsx
+++ b/src/app/(main)/projection/page.tsx
@@ -128,15 +128,11 @@ export default function ProjectionPage() {
     <>
       <StructuredData data={schema} />
       <div className="flex flex-col gap-8">
-        <div className="text-center">
-          <Typography type="h1" weight="bold" className="mb-4 text-balance">
+        <div className="mx-auto flex max-w-3xl flex-col gap-4 text-center">
+          <Typography type="h1">
             Will Your CPF Be Enough for Retirement?
           </Typography>
-          <Typography
-            color="muted"
-            data-projection-intro
-            className="mx-auto max-w-3xl"
-          >
+          <Typography color="muted" data-projection-intro>
             Project your CPF balances using conservative floor rates, current
             contribution rules, and key milestones like the age 55 transfer to
             your Retirement Account. You can also test how housing withdrawals,

--- a/src/app/(main)/projection/page.tsx
+++ b/src/app/(main)/projection/page.tsx
@@ -1,3 +1,4 @@
+import { Typography } from "@heroui/react";
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import type { Graph } from "schema-dts";
@@ -128,15 +129,19 @@ export default function ProjectionPage() {
       <StructuredData data={schema} />
       <div className="flex flex-col gap-8">
         <div className="text-center">
-          <h1 className="mb-4 font-bold text-3xl text-foreground tracking-tight md:text-4xl">
+          <Typography type="h1" weight="bold" className="mb-4 text-balance">
             Will Your CPF Be Enough for Retirement?
-          </h1>
-          <p data-projection-intro className="mx-auto max-w-3xl text-muted">
+          </Typography>
+          <Typography
+            color="muted"
+            data-projection-intro
+            className="mx-auto max-w-3xl"
+          >
             Project your CPF balances using conservative floor rates, current
             contribution rules, and key milestones like the age 55 transfer to
             your Retirement Account. You can also test how housing withdrawals,
             annual top-ups, and OA to SA transfers may change the outcome.
-          </p>
+          </Typography>
         </div>
         <Suspense
           fallback={

--- a/src/app/(main)/retirement-readiness/page.tsx
+++ b/src/app/(main)/retirement-readiness/page.tsx
@@ -1,3 +1,4 @@
+import { Typography } from "@heroui/react";
 import type { Metadata } from "next";
 import type { Graph } from "schema-dts";
 import ReadinessScoreForm from "@/components/retirement-readiness/readiness-score-form";
@@ -61,15 +62,19 @@ export default function RetirementReadinessPage() {
       <StructuredData data={schema} />
       <div className="flex flex-col gap-8">
         <div className="text-center">
-          <h1 className="mb-4 font-bold text-3xl text-foreground tracking-tight md:text-4xl">
+          <Typography type="h1" weight="bold" className="mb-4 text-balance">
             How Ready Is Your CPF Plan?
-          </h1>
-          <p data-readiness-intro className="mx-auto max-w-3xl text-muted">
+          </Typography>
+          <Typography
+            color="muted"
+            data-readiness-intro
+            className="mx-auto max-w-3xl"
+          >
             This 5-question score is meant to surface the next CPF planning gap
             worth fixing. It is not a guarantee of retirement adequacy. It is a
             faster way to decide whether you should use the projection tool, the
             CPF LIFE estimator, or the calculator next.
-          </p>
+          </Typography>
         </div>
         <ReadinessScoreForm />
       </div>

--- a/src/app/(main)/retirement-readiness/page.tsx
+++ b/src/app/(main)/retirement-readiness/page.tsx
@@ -61,15 +61,9 @@ export default function RetirementReadinessPage() {
     <>
       <StructuredData data={schema} />
       <div className="flex flex-col gap-8">
-        <div className="text-center">
-          <Typography type="h1" weight="bold" className="mb-4 text-balance">
-            How Ready Is Your CPF Plan?
-          </Typography>
-          <Typography
-            color="muted"
-            data-readiness-intro
-            className="mx-auto max-w-3xl"
-          >
+        <div className="mx-auto flex max-w-3xl flex-col gap-4 text-center">
+          <Typography type="h1">How Ready Is Your CPF Plan?</Typography>
+          <Typography color="muted" data-readiness-intro>
             This 5-question score is meant to surface the next CPF planning gap
             worth fixing. It is not a guarantee of retirement adequacy. It is a
             faster way to decide whether you should use the projection tool, the

--- a/src/components/calculator/calculator-results.tsx
+++ b/src/components/calculator/calculator-results.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Card, cn } from "@heroui/react";
+import { Card, cn, Typography } from "@heroui/react";
 import { KPI } from "@heroui-pro/react";
 import { formatCurrency } from "@/lib/format";
 import { AssumptionsCard } from "./assumptions-card";
@@ -60,16 +60,16 @@ export function CalculatorResults({ figures }: CalculatorResultsProps) {
           </span>
         </Card.Header>
         <Card.Content className="gap-4">
-          <p className="max-w-[64ch] text-pretty text-[19px] leading-relaxed">
+          <Typography className="max-w-[64ch] text-pretty text-[19px] leading-relaxed">
             {isAboveCeiling
               ? `Your salary is above the ${formatCurrency(figures.ceiling, 0)} ceiling, so contributions stop there. You keep ${formatCurrency(figures.takeHome)}, your employer adds ${formatCurrency(figures.employer)} on top, and ${formatCurrency(figures.total)} lands in your CPF accounts.`
               : `You keep ${formatCurrency(figures.takeHome)} of ${formatCurrency(figures.gross)}. ${formatCurrency(figures.employee)} came out of your pay and your employer added ${formatCurrency(figures.employer)} on top of it, so ${formatCurrency(figures.total)} goes into your accounts.`}
-          </p>
+          </Typography>
           {figures.isIllustrative && (
-            <p className="text-muted text-xs">
+            <Typography color="muted" type="body-xs">
               Illustrative figures for {formatCurrency(ILLUSTRATIVE_INCOME, 0)}{" "}
               a month at {ILLUSTRATIVE_AGE}, enter your own numbers on the left.
-            </p>
+            </Typography>
           )}
         </Card.Content>
       </Card>

--- a/src/components/calculator/calculator-results.tsx
+++ b/src/components/calculator/calculator-results.tsx
@@ -60,11 +60,13 @@ export function CalculatorResults({ figures }: CalculatorResultsProps) {
           </span>
         </Card.Header>
         <Card.Content className="gap-4">
-          <Typography className="max-w-[64ch] text-pretty text-[19px] leading-relaxed">
-            {isAboveCeiling
-              ? `Your salary is above the ${formatCurrency(figures.ceiling, 0)} ceiling, so contributions stop there. You keep ${formatCurrency(figures.takeHome)}, your employer adds ${formatCurrency(figures.employer)} on top, and ${formatCurrency(figures.total)} lands in your CPF accounts.`
-              : `You keep ${formatCurrency(figures.takeHome)} of ${formatCurrency(figures.gross)}. ${formatCurrency(figures.employee)} came out of your pay and your employer added ${formatCurrency(figures.employer)} on top of it, so ${formatCurrency(figures.total)} goes into your accounts.`}
-          </Typography>
+          <div className="max-w-[64ch]">
+            <Typography>
+              {isAboveCeiling
+                ? `Your salary is above the ${formatCurrency(figures.ceiling, 0)} ceiling, so contributions stop there. You keep ${formatCurrency(figures.takeHome)}, your employer adds ${formatCurrency(figures.employer)} on top, and ${formatCurrency(figures.total)} lands in your CPF accounts.`
+                : `You keep ${formatCurrency(figures.takeHome)} of ${formatCurrency(figures.gross)}. ${formatCurrency(figures.employee)} came out of your pay and your employer added ${formatCurrency(figures.employer)} on top of it, so ${formatCurrency(figures.total)} goes into your accounts.`}
+            </Typography>
+          </div>
           {figures.isIllustrative && (
             <Typography color="muted" type="body-xs">
               Illustrative figures for {formatCurrency(ILLUSTRATIVE_INCOME, 0)}{" "}

--- a/src/components/cpf-at-55/at-55-content.tsx
+++ b/src/components/cpf-at-55/at-55-content.tsx
@@ -8,6 +8,7 @@ import {
   Separator,
   Skeleton,
   Surface,
+  Typography,
 } from "@heroui/react";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { shallow } from "zustand/shallow";
@@ -117,9 +118,13 @@ function AccountRow({
         </span>
       </div>
       {body && (
-        <p className="max-w-[52ch] text-muted text-sm leading-relaxed">
+        <Typography
+          color="muted"
+          type="body-sm"
+          className="max-w-[52ch] leading-relaxed"
+        >
           {body}
-        </p>
+        </Typography>
       )}
     </Surface>
   );
@@ -379,9 +384,13 @@ function PromptCard({
         </Card.Title>
       </Card.Header>
       <Card.Content className="flex flex-col gap-4">
-        <p className="max-w-[64ch] text-muted text-sm leading-relaxed">
+        <Typography
+          color="muted"
+          type="body-sm"
+          className="max-w-[64ch] leading-relaxed"
+        >
           {children}
-        </p>
+        </Typography>
         <Link href="/">Go to the home page</Link>
       </Card.Content>
     </Card>
@@ -429,15 +438,18 @@ export default function At55Content(): ReactNode {
         <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">
           At 55
         </span>
-        <h1 className="text-balance font-semibold text-4xl tracking-tight">
+        <Typography type="h1" className="text-balance">
           Your Special Account closes. Here is where the money goes.
-        </h1>
-        <p className="max-w-[76ch] text-pretty text-base text-muted leading-relaxed">
+        </Typography>
+        <Typography
+          color="muted"
+          className="max-w-[76ch] text-pretty leading-relaxed"
+        >
           The CPF Board closed the Special Accounts of about 1.4 million members
           aged 55 and above on 19 January 2025. If you turn 55 after that date,
           it happens on your birthday. Nothing is taken away, it moves, and the
           two destinations behave differently.
-        </p>
+        </Typography>
       </header>
 
       {!mounted && <Skeleton className="h-96 w-full rounded-lg" />}

--- a/src/components/cpf-at-55/at-55-content.tsx
+++ b/src/components/cpf-at-55/at-55-content.tsx
@@ -12,6 +12,7 @@ import {
 } from "@heroui/react";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { shallow } from "zustand/shallow";
+import { Eyebrow } from "@/components/shared/section-header";
 import { getRetirementSumsForYear } from "@/constants/cpf-retirement-sums";
 import { useCpfStore } from "@/hooks/use-cpf-store";
 import { calculateCpfProjection } from "@/lib/calculate-cpf-projection";
@@ -431,9 +432,7 @@ export default function At55Content(): ReactNode {
   return (
     <div className="flex flex-col gap-12">
       <header className="flex flex-col gap-2">
-        <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">
-          At 55
-        </span>
+        <Eyebrow color="muted">At 55</Eyebrow>
         <Typography type="h1">
           Your Special Account closes. Here is where the money goes.
         </Typography>

--- a/src/components/cpf-at-55/at-55-content.tsx
+++ b/src/components/cpf-at-55/at-55-content.tsx
@@ -118,13 +118,11 @@ function AccountRow({
         </span>
       </div>
       {body && (
-        <Typography
-          color="muted"
-          type="body-sm"
-          className="max-w-[52ch] leading-relaxed"
-        >
-          {body}
-        </Typography>
+        <div className="max-w-[52ch]">
+          <Typography color="muted" type="body-sm">
+            {body}
+          </Typography>
+        </div>
       )}
     </Surface>
   );
@@ -384,13 +382,11 @@ function PromptCard({
         </Card.Title>
       </Card.Header>
       <Card.Content className="flex flex-col gap-4">
-        <Typography
-          color="muted"
-          type="body-sm"
-          className="max-w-[64ch] leading-relaxed"
-        >
-          {children}
-        </Typography>
+        <div className="max-w-[64ch]">
+          <Typography color="muted" type="body-sm">
+            {children}
+          </Typography>
+        </div>
         <Link href="/">Go to the home page</Link>
       </Card.Content>
     </Card>
@@ -438,18 +434,17 @@ export default function At55Content(): ReactNode {
         <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">
           At 55
         </span>
-        <Typography type="h1" className="text-balance">
+        <Typography type="h1">
           Your Special Account closes. Here is where the money goes.
         </Typography>
-        <Typography
-          color="muted"
-          className="max-w-[76ch] text-pretty leading-relaxed"
-        >
-          The CPF Board closed the Special Accounts of about 1.4 million members
-          aged 55 and above on 19 January 2025. If you turn 55 after that date,
-          it happens on your birthday. Nothing is taken away, it moves, and the
-          two destinations behave differently.
-        </Typography>
+        <div className="max-w-[76ch]">
+          <Typography color="muted">
+            The CPF Board closed the Special Accounts of about 1.4 million
+            members aged 55 and above on 19 January 2025. If you turn 55 after
+            that date, it happens on your birthday. Nothing is taken away, it
+            moves, and the two destinations behave differently.
+          </Typography>
+        </div>
       </header>
 
       {!mounted && <Skeleton className="h-96 w-full rounded-lg" />}

--- a/src/components/cpf-check/cpf-check-content.tsx
+++ b/src/components/cpf-check/cpf-check-content.tsx
@@ -11,6 +11,7 @@ import {
 } from "@heroui/react";
 import { ArrowRight } from "lucide-react";
 import { type ReactNode, useState } from "react";
+import { Eyebrow } from "@/components/shared/section-header";
 
 interface CheckItem {
   id: string;
@@ -123,9 +124,7 @@ export default function CpfCheckContent(): ReactNode {
   return (
     <div className="flex flex-col gap-12">
       <header className="flex flex-col gap-2">
-        <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">
-          Check
-        </span>
+        <Eyebrow color="muted">Check</Eyebrow>
         <Typography type="h1">
           Five things worth knowing. Which do you already?
         </Typography>

--- a/src/components/cpf-check/cpf-check-content.tsx
+++ b/src/components/cpf-check/cpf-check-content.tsx
@@ -126,17 +126,16 @@ export default function CpfCheckContent(): ReactNode {
         <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">
           Check
         </span>
-        <Typography type="h1" className="text-balance">
+        <Typography type="h1">
           Five things worth knowing. Which do you already?
         </Typography>
-        <Typography
-          color="muted"
-          className="max-w-[76ch] text-pretty leading-relaxed"
-        >
-          Not a score, and no right answer. Tick what you already know and we
-          will point you at the screen that explains each of the rest. Nothing
-          is recorded and no email is asked for.
-        </Typography>
+        <div className="max-w-[76ch]">
+          <Typography color="muted">
+            Not a score, and no right answer. Tick what you already know and we
+            will point you at the screen that explains each of the rest. Nothing
+            is recorded and no email is asked for.
+          </Typography>
+        </div>
       </header>
 
       <div className="grid items-start gap-8 lg:grid-cols-[1fr_340px]">
@@ -156,7 +155,7 @@ export default function CpfCheckContent(): ReactNode {
             <span className="font-mono text-[10px] text-muted uppercase tracking-[0.12em]">
               Where to read the rest
             </span>
-            <Typography className="leading-relaxed">
+            <Typography>
               {allTicked
                 ? "All five ticked. Nothing left to point you at, the screens are still there if you want the numbers for your own salary."
                 : `You have ticked ${tickedIds.length} of five. Here is where each of the others is explained, in your own numbers.`}
@@ -172,11 +171,7 @@ export default function CpfCheckContent(): ReactNode {
             )}
             <div className="flex flex-col gap-4">
               <Separator variant="secondary" />
-              <Typography
-                color="muted"
-                type="body-xs"
-                className="leading-relaxed"
-              >
+              <Typography color="muted" type="body-xs">
                 We do not assess your readiness or suggest what to do, this only
                 shows which explanation you have not read yet.
               </Typography>

--- a/src/components/cpf-check/cpf-check-content.tsx
+++ b/src/components/cpf-check/cpf-check-content.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Card, Checkbox, cn, Link, Separator, Surface } from "@heroui/react";
+import {
+  Card,
+  Checkbox,
+  cn,
+  Link,
+  Separator,
+  Surface,
+  Typography,
+} from "@heroui/react";
 import { ArrowRight } from "lucide-react";
 import { type ReactNode, useState } from "react";
 
@@ -118,14 +126,17 @@ export default function CpfCheckContent(): ReactNode {
         <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">
           Check
         </span>
-        <h1 className="text-balance font-semibold text-4xl tracking-tight">
+        <Typography type="h1" className="text-balance">
           Five things worth knowing. Which do you already?
-        </h1>
-        <p className="max-w-[76ch] text-pretty text-base text-muted leading-relaxed">
+        </Typography>
+        <Typography
+          color="muted"
+          className="max-w-[76ch] text-pretty leading-relaxed"
+        >
           Not a score, and no right answer. Tick what you already know and we
           will point you at the screen that explains each of the rest. Nothing
           is recorded and no email is asked for.
-        </p>
+        </Typography>
       </header>
 
       <div className="grid items-start gap-8 lg:grid-cols-[1fr_340px]">
@@ -145,11 +156,11 @@ export default function CpfCheckContent(): ReactNode {
             <span className="font-mono text-[10px] text-muted uppercase tracking-[0.12em]">
               Where to read the rest
             </span>
-            <p className="text-base leading-relaxed">
+            <Typography className="leading-relaxed">
               {allTicked
                 ? "All five ticked. Nothing left to point you at, the screens are still there if you want the numbers for your own salary."
                 : `You have ticked ${tickedIds.length} of five. Here is where each of the others is explained, in your own numbers.`}
-            </p>
+            </Typography>
             {untickedItems.length > 0 && (
               <ul className="flex flex-col gap-2">
                 {untickedItems.map((item) => (
@@ -161,10 +172,14 @@ export default function CpfCheckContent(): ReactNode {
             )}
             <div className="flex flex-col gap-4">
               <Separator variant="secondary" />
-              <p className="text-[12px] text-muted leading-relaxed">
+              <Typography
+                color="muted"
+                type="body-xs"
+                className="leading-relaxed"
+              >
                 We do not assess your readiness or suggest what to do, this only
                 shows which explanation you have not read yet.
-              </p>
+              </Typography>
             </div>
           </Card.Content>
         </Card>

--- a/src/components/cpf-life/cpf-life-content.tsx
+++ b/src/components/cpf-life/cpf-life-content.tsx
@@ -10,6 +10,7 @@ import {
   Separator,
   ToggleButton,
   ToggleButtonGroup,
+  Typography,
 } from "@heroui/react";
 import { BarChart } from "@heroui-pro/react";
 import { type Key, useEffect, useMemo, useState } from "react";
@@ -250,19 +251,19 @@ export function CpfLifeContent() {
           </div>
 
           {!hasProjection && (
-            <p className="text-muted text-xs">
+            <Typography color="muted" type="body-xs">
               Enter salary and DOB on the <Link href="/">home page</Link> to use
               your own projection.
-            </p>
+            </Typography>
           )}
 
-          <p className="max-w-[64ch] text-[19px] leading-relaxed">
+          <Typography className="max-w-[64ch] text-[19px] leading-relaxed">
             A Retirement Account of {monthly(raBalance)} at 65 supports roughly{" "}
             {monthly(standard)} a month on the Standard plan,{" "}
             {monthly(escalating)} rising 2% a year on Escalating, or{" "}
             {monthly(basic)} on Basic. Over twenty years the Escalating payout
             reaches {monthly(escalating85)}.
-          </p>
+          </Typography>
         </Card.Content>
       </Card>
 
@@ -353,10 +354,10 @@ export function CpfLifeContent() {
               ))}
             </ol>
             <Separator />
-            <p className="text-muted text-xs">
+            <Typography color="muted" type="body-xs">
               Indicative only. Use CPF's own payout estimator for figures tied
               to your record. SimplyCPF does not recommend a plan.
-            </p>
+            </Typography>
           </Card.Content>
         </Card>
       </div>

--- a/src/components/cpf-life/cpf-life-content.tsx
+++ b/src/components/cpf-life/cpf-life-content.tsx
@@ -257,13 +257,15 @@ export function CpfLifeContent() {
             </Typography>
           )}
 
-          <Typography className="max-w-[64ch] text-[19px] leading-relaxed">
-            A Retirement Account of {monthly(raBalance)} at 65 supports roughly{" "}
-            {monthly(standard)} a month on the Standard plan,{" "}
-            {monthly(escalating)} rising 2% a year on Escalating, or{" "}
-            {monthly(basic)} on Basic. Over twenty years the Escalating payout
-            reaches {monthly(escalating85)}.
-          </Typography>
+          <div className="max-w-[64ch]">
+            <Typography>
+              A Retirement Account of {monthly(raBalance)} at 65 supports
+              roughly {monthly(standard)} a month on the Standard plan,{" "}
+              {monthly(escalating)} rising 2% a year on Escalating, or{" "}
+              {monthly(basic)} on Basic. Over twenty years the Escalating payout
+              reaches {monthly(escalating85)}.
+            </Typography>
+          </div>
         </Card.Content>
       </Card>
 

--- a/src/components/home/home-confusions.tsx
+++ b/src/components/home/home-confusions.tsx
@@ -1,4 +1,4 @@
-import { Card } from "@heroui/react";
+import { Card, Typography } from "@heroui/react";
 import type { Route } from "next";
 import Link from "next/link";
 
@@ -43,12 +43,12 @@ export function HomeConfusions() {
   return (
     <section className="flex flex-col gap-6">
       <div className="flex flex-wrap items-baseline justify-between gap-4">
-        <h2 className="font-semibold text-base tracking-tight">
+        <Typography type="h2" className="text-base tracking-tight">
           The four things people actually get wrong
-        </h2>
-        <span className="text-muted text-xs">
+        </Typography>
+        <Typography color="muted" type="body-xs">
           Each one is a screen, not an article
-        </span>
+        </Typography>
       </div>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {confusions.map((confusion) => (

--- a/src/components/home/home-confusions.tsx
+++ b/src/components/home/home-confusions.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Card, Typography } from "@heroui/react";
 import type { Route } from "next";
 import Link from "next/link";

--- a/src/components/home/home-confusions.tsx
+++ b/src/components/home/home-confusions.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Card, Typography } from "@heroui/react";
 import type { Route } from "next";
 import Link from "next/link";
@@ -45,12 +43,7 @@ export function HomeConfusions() {
   return (
     <section className="flex flex-col gap-6">
       <div className="flex flex-wrap items-baseline justify-between gap-4">
-        <Typography
-          type="h6"
-          render={({ children, ...domProps }) => (
-            <h2 {...domProps}>{children}</h2>
-          )}
-        >
+        <Typography type="h2">
           The four things people actually get wrong
         </Typography>
         <Typography color="muted" type="body-xs">

--- a/src/components/home/home-confusions.tsx
+++ b/src/components/home/home-confusions.tsx
@@ -43,7 +43,12 @@ export function HomeConfusions() {
   return (
     <section className="flex flex-col gap-6">
       <div className="flex flex-wrap items-baseline justify-between gap-4">
-        <Typography type="h2" className="text-base tracking-tight">
+        <Typography
+          type="h6"
+          render={({ children, ...domProps }) => (
+            <h2 {...domProps}>{children}</h2>
+          )}
+        >
           The four things people actually get wrong
         </Typography>
         <Typography color="muted" type="body-xs">
@@ -58,7 +63,7 @@ export function HomeConfusions() {
                 <span className="font-mono text-[10px] text-muted uppercase tracking-[0.12em]">
                   {confusion.eyebrow}
                 </span>
-                <Card.Title className="text-balance font-semibold text-[15px]">
+                <Card.Title className="font-semibold text-[15px]">
                   {confusion.title}
                 </Card.Title>
                 <Card.Description className="text-[13px] text-muted leading-relaxed">

--- a/src/components/home/home-hero.tsx
+++ b/src/components/home/home-hero.tsx
@@ -12,6 +12,7 @@ import {
   TextField,
   ToggleButton,
   ToggleButtonGroup,
+  Typography,
 } from "@heroui/react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -98,14 +99,16 @@ export function HomeHero() {
     <section className="grid gap-14 lg:grid-cols-[1.02fr_0.98fr]">
       <div className="flex flex-col gap-6">
         <Eyebrow withDot>Updated for 1 Jan 2026 rates</Eyebrow>
-        <h1 className="text-balance font-semibold text-5xl tracking-tight md:text-6xl">
+        <Typography type="h1" className="text-5xl md:text-6xl">
           Five questions about CPF, answered in plain English.
-        </h1>
-        <p className="max-w-[47ch] text-pretty text-[17.5px] text-muted leading-relaxed">
-          Where this month&rsquo;s money went. What happens at 55. What a flat
-          really costs your OA. What arrives every month at 65. No sign-up, no
-          jargon, no advice, just the arithmetic, with every assumption shown.
-        </p>
+        </Typography>
+        <div className="max-w-[47ch]">
+          <Typography color="muted">
+            Where this month&rsquo;s money went. What happens at 55. What a flat
+            really costs your OA. What arrives every month at 65. No sign-up, no
+            jargon, no advice, just the arithmetic, with every assumption shown.
+          </Typography>
+        </div>
 
         <div className="flex flex-col gap-4 sm:flex-row">
           <Card variant="secondary" className="flex-[1.3]">
@@ -192,11 +195,13 @@ export function HomeHero() {
           </ToggleButtonGroup>
         </div>
 
-        <p className="max-w-[54ch] text-muted text-xs leading-relaxed">
-          Nothing leaves your browser. SimplyCPF is independent and not
-          affiliated with the CPF Board. Every figure is an estimate from
-          published rates, not financial advice.
-        </p>
+        <div className="max-w-[54ch]">
+          <Typography color="muted" type="body-xs">
+            Nothing leaves your browser. SimplyCPF is independent and not
+            affiliated with the CPF Board. Every figure is an estimate from
+            published rates, not financial advice.
+          </Typography>
+        </div>
       </div>
 
       <Card className="h-fit shadow-(--overlay-shadow)">

--- a/src/components/home/home-hero.tsx
+++ b/src/components/home/home-hero.tsx
@@ -99,7 +99,7 @@ export function HomeHero() {
     <section className="grid gap-14 lg:grid-cols-[1.02fr_0.98fr]">
       <div className="flex flex-col gap-6">
         <Eyebrow withDot>Updated for 1 Jan 2026 rates</Eyebrow>
-        <Typography type="h1" className="text-5xl md:text-6xl">
+        <Typography type="h1">
           Five questions about CPF, answered in plain English.
         </Typography>
         <div className="max-w-[47ch]">

--- a/src/components/home/home-three-ages.tsx
+++ b/src/components/home/home-three-ages.tsx
@@ -1,4 +1,4 @@
-import { Card, Chip, Separator } from "@heroui/react";
+import { Card, Chip, Separator, Typography } from "@heroui/react";
 import { Fragment } from "react";
 
 const ages: { figure: string; note?: string; label: string; body: string }[] = [
@@ -53,9 +53,9 @@ export function HomeThreeAges() {
                 )}
               </span>
               <span className="font-semibold text-sm">{age.label}</span>
-              <span className="text-[13px] text-muted leading-relaxed">
+              <Typography color="muted" type="body-sm">
                 {age.body}
-              </span>
+              </Typography>
             </div>
           </Fragment>
         ))}

--- a/src/components/investments/cpf-investment-comparison.tsx
+++ b/src/components/investments/cpf-investment-comparison.tsx
@@ -262,7 +262,14 @@ export function CPFInvestmentComparison() {
             aria-label="Investment growth comparison chart showing projected returns over time for selected scenarios"
             className="flex flex-col gap-4"
           >
-            <Typography type="h5">Growth Over Time</Typography>
+            <Typography
+              type="h5"
+              render={({ children, ...domProps }) => (
+                <h3 {...domProps}>{children}</h3>
+              )}
+            >
+              Growth Over Time
+            </Typography>
             <LineChart data={chartData} height={400}>
               <LineChart.Grid strokeDasharray="3 3" />
               <LineChart.XAxis

--- a/src/components/investments/cpf-investment-comparison.tsx
+++ b/src/components/investments/cpf-investment-comparison.tsx
@@ -262,14 +262,7 @@ export function CPFInvestmentComparison() {
             aria-label="Investment growth comparison chart showing projected returns over time for selected scenarios"
             className="flex flex-col gap-4"
           >
-            <Typography
-              type="h5"
-              render={({ children, ...domProps }) => (
-                <h3 {...domProps}>{children}</h3>
-              )}
-            >
-              Growth Over Time
-            </Typography>
+            <Typography type="h3">Growth Over Time</Typography>
             <LineChart data={chartData} height={400}>
               <LineChart.Grid strokeDasharray="3 3" />
               <LineChart.XAxis

--- a/src/components/investments/cpf-investment-comparison.tsx
+++ b/src/components/investments/cpf-investment-comparison.tsx
@@ -10,6 +10,7 @@ import {
   Table,
   ToggleButton,
   ToggleButtonGroup,
+  Typography,
 } from "@heroui/react";
 import { LineChart } from "@heroui-pro/react";
 import posthog from "posthog-js";
@@ -261,7 +262,7 @@ export function CPFInvestmentComparison() {
             aria-label="Investment growth comparison chart showing projected returns over time for selected scenarios"
             className="flex flex-col gap-4"
           >
-            <h3 className="font-semibold text-lg">Growth Over Time</h3>
+            <Typography type="h5">Growth Over Time</Typography>
             <LineChart data={chartData} height={400}>
               <LineChart.Grid strokeDasharray="3 3" />
               <LineChart.XAxis

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,4 +1,4 @@
-import { Link } from "@heroui/react";
+import { Link, Typography } from "@heroui/react";
 import type { Route } from "next";
 import { Wordmark } from "@/components/shared/wordmark";
 
@@ -20,11 +20,14 @@ export function Footer() {
     <footer className="border-border border-t">
       <div className="container mx-auto flex flex-col gap-6 px-4 py-8">
         <div className="flex flex-col justify-between gap-6 md:flex-row md:items-center">
-          <p className="max-w-[74ch] text-muted text-xs leading-relaxed">
-            SimplyCPF is an independent, open-source tool. Not affiliated with
-            or endorsed by the CPF Board. Figures are estimates based on
-            published rates and the assumptions you enter, not financial advice.
-          </p>
+          <div className="max-w-[74ch]">
+            <Typography color="muted" type="body-xs">
+              SimplyCPF is an independent, open-source tool. Not affiliated with
+              or endorsed by the CPF Board. Figures are estimates based on
+              published rates and the assumptions you enter, not financial
+              advice.
+            </Typography>
+          </div>
           <nav aria-label="Footer" className="flex items-center gap-4 text-sm">
             {primaryLinks.map((link) => (
               <Link key={link.href} href={link.href}>

--- a/src/components/shared/section-header.tsx
+++ b/src/components/shared/section-header.tsx
@@ -1,8 +1,11 @@
 import { cn } from "@heroui/react";
 import type { ReactElement, ReactNode } from "react";
 
+type EyebrowColor = "accent" | "muted";
+
 interface EyebrowProps {
   children: ReactNode;
+  color?: EyebrowColor;
   withDot?: boolean;
   className?: string;
 }
@@ -13,6 +16,7 @@ interface EyebrowProps {
  */
 export function Eyebrow({
   children,
+  color = "accent",
   withDot,
   className,
 }: EyebrowProps): ReactElement {
@@ -21,7 +25,12 @@ export function Eyebrow({
       {withDot && (
         <span aria-hidden className="size-1.5 rounded-full bg-accent" />
       )}
-      <span className="font-mono text-[10.5px] text-accent uppercase tracking-[0.13em]">
+      <span
+        className={cn(
+          "font-mono text-[10.5px] uppercase tracking-[0.13em]",
+          color === "muted" ? "text-muted" : "text-accent",
+        )}
+      >
         {children}
       </span>
     </span>

--- a/src/components/what-if/what-if-content.tsx
+++ b/src/components/what-if/what-if-content.tsx
@@ -10,6 +10,7 @@ import {
   Skeleton,
   ToggleButton,
   ToggleButtonGroup,
+  Typography,
 } from "@heroui/react";
 import { EmptyState } from "@heroui-pro/react";
 import {
@@ -281,17 +282,17 @@ function AssumptionsCard() {
               <span className={`${MONO_LABEL} text-muted`}>
                 {String(index + 1).padStart(2, "0")}
               </span>
-              <p className="max-w-[64ch] text-muted text-sm leading-relaxed">
+              <Typography color="muted" type="body-sm">
                 {assumption}
-              </p>
+              </Typography>
             </div>
           ))}
         </div>
         <Separator />
-        <p className="max-w-[64ch] text-muted text-sm leading-relaxed">
+        <Typography color="muted" type="body-sm">
           A projection is a calculation about assumptions, not a forecast about
           you. Estimates only, not financial advice.
-        </p>
+        </Typography>
       </Card.Content>
     </Card>
   );
@@ -411,13 +412,13 @@ export default function WhatIfContent() {
         <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">
           Compare
         </span>
-        <h1 className="text-balance font-semibold text-4xl tracking-tight">
-          Two sets of assumptions, side by side
-        </h1>
-        <p className="max-w-[76ch] text-pretty text-base text-muted leading-relaxed">
-          Change one thing and see what the arithmetic does. This tool states
-          differences; it does not suggest which column you should prefer.
-        </p>
+        <Typography type="h1">Two sets of assumptions, side by side</Typography>
+        <div className="max-w-[76ch]">
+          <Typography color="muted">
+            Change one thing and see what the arithmetic does. This tool states
+            differences; it does not suggest which column you should prefer.
+          </Typography>
+        </div>
       </header>
 
       <Card>
@@ -464,9 +465,9 @@ export default function WhatIfContent() {
               <NumberField.Input className="w-full" />
             </NumberField.Group>
           </NumberField>
-          <p className="max-w-[64ch] text-[13px] text-muted leading-relaxed">
+          <Typography color="muted" type="body-xs">
             {mounted ? descriptions[scenario] : null}
-          </p>
+          </Typography>
         </Card.Content>
       </Card>
 

--- a/src/components/what-if/what-if-content.tsx
+++ b/src/components/what-if/what-if-content.tsx
@@ -468,9 +468,11 @@ export default function WhatIfContent() {
               <NumberField.Input className="w-full" />
             </NumberField.Group>
           </NumberField>
-          <Typography color="muted" type="body-xs">
-            {mounted ? descriptions[scenario] : null}
-          </Typography>
+          <div className="max-w-[64ch]">
+            <Typography color="muted" type="body-xs">
+              {mounted ? descriptions[scenario] : null}
+            </Typography>
+          </div>
         </Card.Content>
       </Card>
 

--- a/src/components/what-if/what-if-content.tsx
+++ b/src/components/what-if/what-if-content.tsx
@@ -21,6 +21,7 @@ import {
 } from "nuqs";
 import { Fragment, useEffect, useMemo, useState } from "react";
 import type { Key } from "react-aria-components";
+import { Eyebrow } from "@/components/shared/section-header";
 import { useCpfStore } from "@/hooks/use-cpf-store";
 import { estimateCpfLife } from "@/lib/calculate-cpf-projection";
 import {
@@ -409,9 +410,7 @@ export default function WhatIfContent() {
   return (
     <div className="flex flex-col gap-12">
       <header className="flex flex-col gap-2">
-        <span className="font-mono text-[10.5px] text-muted uppercase tracking-[0.13em]">
-          Compare
-        </span>
+        <Eyebrow color="muted">Compare</Eyebrow>
         <Typography type="h1">Two sets of assumptions, side by side</Typography>
         <div className="max-w-[76ch]">
           <Typography color="muted">

--- a/src/components/what-if/what-if-content.tsx
+++ b/src/components/what-if/what-if-content.tsx
@@ -283,17 +283,21 @@ function AssumptionsCard() {
               <span className={`${MONO_LABEL} text-muted`}>
                 {String(index + 1).padStart(2, "0")}
               </span>
-              <Typography color="muted" type="body-sm">
-                {assumption}
-              </Typography>
+              <div className="max-w-[64ch]">
+                <Typography color="muted" type="body-sm">
+                  {assumption}
+                </Typography>
+              </div>
             </div>
           ))}
         </div>
         <Separator />
-        <Typography color="muted" type="body-sm">
-          A projection is a calculation about assumptions, not a forecast about
-          you. Estimates only, not financial advice.
-        </Typography>
+        <div className="max-w-[64ch]">
+          <Typography color="muted" type="body-sm">
+            A projection is a calculation about assumptions, not a forecast
+            about you. Estimates only, not financial advice.
+          </Typography>
+        </div>
       </Card.Content>
     </Card>
   );


### PR DESCRIPTION
- Replace hand-rolled h1/lede markup with HeroUI Typography on high-traffic product pages
- Keep mono eyebrows, Card compounds, PDFs, and docs on their existing patterns